### PR TITLE
[iOS/Mac] Add SdkNotInstalledReason

### DIFF
--- a/Xamarin.MacDev/AppleSdkSettings.cs
+++ b/Xamarin.MacDev/AppleSdkSettings.cs
@@ -42,6 +42,8 @@ namespace Xamarin.MacDev
 		};
 		static DateTime lastWritten;
 
+		public static string SdkNotInstalledReason { get; private set; }
+
 		static void GetNewPaths (string root, out string xcode, out string vplist, out string devroot)
 		{
 			xcode = root;
@@ -195,10 +197,12 @@ namespace Xamarin.MacDev
 						break;
 					}
 
-					LoggingService.LogInfo ("A valid Xcode installation was not found at '{0}'", v);
+					SdkNotInstalledReason += string.Format ("A valid Xcode installation was not found at '{0}'\n", v);
+					LoggingService.LogInfo (SdkNotInstalledReason);
 				}
 			} else if (!ValidateSdkLocation (DeveloperRoot, out xcode, out vplist, out devroot)) {
-				LoggingService.LogError ("A valid Xcode installation was not found at the configured location: '{0}'", DeveloperRoot);
+				SdkNotInstalledReason = string.Format ("A valid Xcode installation was not found at the configured location: '{0}'", DeveloperRoot);
+				LoggingService.LogError (SdkNotInstalledReason);
 				SetInvalid ();
 				return;
 			} else {
@@ -245,7 +249,8 @@ namespace Xamarin.MacDev
 				AnalyticsService.ReportContextProperty ("XS.Core.SDK.Xcode.Version", XcodeVersion.ToString ());
 				IsValid = true;
 			} catch (Exception ex) {
-				LoggingService.LogError ("Error loading Xcode information for prefix '" + DeveloperRoot + "'", ex);
+				SdkNotInstalledReason = string.Format ("Error loading Xcode information for prefix '" + DeveloperRoot + "'");
+				LoggingService.LogError (SdkNotInstalledReason, ex);
 				SetInvalid ();
 			}
 		}

--- a/Xamarin.MacDev/XamMacSdk.cs
+++ b/Xamarin.MacDev/XamMacSdk.cs
@@ -29,6 +29,7 @@ namespace Xamarin.MacDev
 		public bool SupportsFullProfile { get; private set; }
 		public bool SupportsMonoSymbolArchive { get; private set; }
 		public MacOSXSdkVersion Version { get; private set; }
+		public string SdkNotInstalledReason { get; private set; }
 
 		public string FrameworkDirectory { get; private set; }
 		public string MmpPath { get; private set; }
@@ -146,10 +147,12 @@ namespace Xamarin.MacDev
 			IsInstalled = false;
 			Version = new MacOSXSdkVersion ();
 
+			SdkNotInstalledReason = string.Format ("Xamarin.Mac not installed. Can't find {0}.", pathMissing);
+
 			if (error)
-				LoggingService.LogError ("Xamarin.Mac not installed. Can't find {0}.", pathMissing);
+				LoggingService.LogError (SdkNotInstalledReason);
 			else
-				LoggingService.LogInfo ("Xamarin.Mac not installed. Can't find {0}.", pathMissing);
+				LoggingService.LogInfo (SdkNotInstalledReason);
 		}
 
 		MacOSXSdkVersion ReadVersion (string versionPath)


### PR DESCRIPTION
This lets the IDE explain in the About section, the exact reason it couldn't load
a given SDK.

Also includes some log message refinements.