### PR TITLE
Use the right `Task` method to run on a background thread

### DIFF
--- a/Xamarin.MacDev/PListObject.cs
+++ b/Xamarin.MacDev/PListObject.cs
@@ -323,7 +323,7 @@ namespace Xamarin.MacDev
 
 		public static Task<PObject> FromFileAsync (string fileName)
 		{
-			return Task<PObject>.Factory.StartNew (() => {
+			return Task.Run (() => {
 				bool isBinary;
 				return FromFile (fileName, out isBinary);
 			});
@@ -355,7 +355,7 @@ namespace Xamarin.MacDev
 
 		public Task SaveAsync (string filename, bool atomic = false, bool binary = false)
 		{
-			return Task.Factory.StartNew (() => Save (filename, atomic, binary));
+			return Task.Run (() => Save (filename, atomic, binary));
 		}
 
 		public void Save (string filename, bool atomic = false, bool binary = false)
@@ -751,7 +751,7 @@ namespace Xamarin.MacDev
 
 		public new static Task<PDictionary> FromFileAsync (string fileName)
 		{
-			return Task<PDictionary>.Factory.StartNew (() => {
+			return Task.Run (() => {
 				bool isBinary;
 				return FromFile (fileName, out isBinary);
 			});


### PR DESCRIPTION
Task.StartNew can run on any thread depending on who is
invoking it. What we want is to run on a background thread,
so we should use Task.Run.

Alternatively we can use Task.StartNew (..., TaskScheduler.Default);
but it is cleaner and simpler to use `Run`.