### PR TITLE
[iOS] Only use File.GetLastWriteTimeUtc

### DIFF
--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -57,7 +57,7 @@ namespace Xamarin.MacDev
 			IsInstalled = File.Exists (Path.Combine (DevicePlatform, "Info.plist"));
 
 			if (IsInstalled) {
-				File.GetLastWriteTime (VersionPlist);
+				File.GetLastWriteTimeUtc (VersionPlist);
 				InstalledSdkVersions = EnumerateSdks (Path.Combine (DevicePlatform, "Developer/SDKs"), DevicePlatformName);
 				InstalledSimVersions = EnumerateSdks (Path.Combine (SimPlatform, "Developer/SDKs"), SimulatorPlatformName);
 			} else {

--- a/Xamarin.MacDev/AppleSdkSettings.cs
+++ b/Xamarin.MacDev/AppleSdkSettings.cs
@@ -227,7 +227,7 @@ namespace Xamarin.MacDev
 					return;
 				}
 				
-				lastWritten = File.GetLastWriteTime (plist);
+				lastWritten = File.GetLastWriteTimeUtc (plist);
 				
 				XcodeVersion = new Version (3, 2, 6);
 				XcodeRevision = "0";
@@ -271,7 +271,7 @@ namespace Xamarin.MacDev
 			//var mtime = DateTime.MinValue;
 
 			//if (File.Exists (plist))
-			//	mtime = File.GetLastWriteTime (plist);
+			//	mtime = File.GetLastWriteTimeUtc (plist);
 
 			//if (mtime != lastWritten) {
 			//	Init ();

--- a/Xamarin.MacDev/MonoMacSdk.cs
+++ b/Xamarin.MacDev/MonoMacSdk.cs
@@ -55,7 +55,7 @@ namespace Xamarin.MacDev
 			IsInstalled = File.Exists (LegacyFrameworkAssembly);
 			
 			if (IsInstalled) {
-				lastExeWrite = File.GetLastWriteTime (LegacyFrameworkAssembly);
+				lastExeWrite = File.GetLastWriteTimeUtc (LegacyFrameworkAssembly);
 				Version = ReadVersion ();
 				if (Version.IsUseDefault)
 					LoggingService.LogInfo ("Found MonoMac.");
@@ -89,7 +89,7 @@ namespace Xamarin.MacDev
 		{
 			DateTime lastWrite = DateTime.MinValue;
 			try {
-				lastWrite = File.GetLastWriteTime (LegacyFrameworkAssembly);
+				lastWrite = File.GetLastWriteTimeUtc (LegacyFrameworkAssembly);
 				if (lastWrite == lastExeWrite)
 					return;
 			} catch (IOException) {

--- a/Xamarin.MacDev/MonoTouchSdk.cs
+++ b/Xamarin.MacDev/MonoTouchSdk.cs
@@ -199,7 +199,7 @@ namespace Xamarin.MacDev
 			string mtouch = null;
 			if (IsInstalled) {
 				mtouch = Path.Combine (BinDir, "mtouch");
-				lastMTExeWrite = File.GetLastWriteTime (mtouch);
+				lastMTExeWrite = File.GetLastWriteTimeUtc (mtouch);
 				Version = ReadVersion ();
 
 				if (Version.CompareTo (requiredXI) >= 0) {
@@ -351,7 +351,7 @@ namespace Xamarin.MacDev
 		{
 			if (IsInstalled) {
 				try {
-					var lastWrite = File.GetLastWriteTime (Path.Combine (BinDir, "mtouch"));
+					var lastWrite = File.GetLastWriteTimeUtc (Path.Combine (BinDir, "mtouch"));
 					if (lastWrite == lastMTExeWrite)
 						return;
 				} catch (IOException) {


### PR DESCRIPTION
Instead of just using `File.GetLastWriteTime`.
Fixes bug #51694: Use File.GetLastWriteTimeUtc not File.GetLastWriteTime
https://bugzilla.xamarin.com/show_bug.cgi?id=51694