### PR TITLE
Add in MicroBuild to all projects for signing

### DIFF
--- a/Xamarin.MacDev/Xamarin.MacDev.csproj
+++ b/Xamarin.MacDev/Xamarin.MacDev.csproj
@@ -32,6 +32,18 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="MicroBuild.Core">
+      <Version>0.3.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
+      <Authenticode>Microsoft</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/Xamarin.MacDev/Xamarin.iOSDev.csproj
+++ b/Xamarin.MacDev/Xamarin.iOSDev.csproj
@@ -32,6 +32,18 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="MicroBuild.Core">
+      <Version>0.3.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
+      <Authenticode>Microsoft</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
We'll be using MicroBuild to sign all the binaries built in AzDO. This repository is a submodule of other projects (e.g. https://github.com/xamarin/profiler) that require MicroBuild to be listed in all nested .csprojs.

This should not negatively affect local/CI builds; the only noticeable change should be that an extra .nupkg (MicroBuild.Core) is downloaded during build.