### PR TITLE
[d15-9] Keys in property list dictionaries aren't necessarily unique. Fixes xamarin-macios#5277. (#39)

### DIFF
--- a/Xamarin.MacDev/PListObject.cs
+++ b/Xamarin.MacDev/PListObject.cs
@@ -2025,8 +2025,10 @@ namespace Xamarin.MacDev
 
 						ReadObjectHead ();
 						var result = ReadObject ();
-						if (result != null)
-							dict.Add (key, result);
+						if (result != null) {
+							// Keys are not required to be unique. The last entry wins.
+							dict [key] = result;
+						}
 
 						do {
 							if (reader.NodeType == XmlNodeType.Element && reader.Name == "key")


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/5277.