### PR TITLE
Add ARM64_32 to the list of supported architectures

### DIFF
--- a/Xamarin.MacDev/IPhoneArchitecture.cs
+++ b/Xamarin.MacDev/IPhoneArchitecture.cs
@@ -22,5 +22,6 @@ namespace Xamarin.MacDev
 		ARMv7s       = 16,
 		ARMv7k       = 32,
 		ARM64        = 64,
+		ARM64_32     = 128,
 	}
 }


### PR DESCRIPTION
Context: https://github.com/mono/mono/issues/10641