### PR TITLE
Add support for Apple Development certificates

### DIFF
--- a/Xamarin.MacDev/IPhoneCertificate.cs
+++ b/Xamarin.MacDev/IPhoneCertificate.cs
@@ -13,8 +13,8 @@ namespace Xamarin.MacDev
 {
 	public static class IPhoneCertificate
 	{
-		public static readonly string[] DevelopmentPrefixes = { "iPhone Developer", "iOS Development" };
-		public static readonly string[] DistributionPrefixes = { "iPhone Distribution", "iOS Distribution" };
+		public static readonly string[] DevelopmentPrefixes = { "iPhone Developer", "iOS Development", "Apple Development" };
+		public static readonly string[] DistributionPrefixes = { "iPhone Distribution", "iOS Distribution", "Apple Distribution" };
 
 		public static bool IsDevelopment (string name)
 		{


### PR DESCRIPTION
Does what the title says. See https://github.com/xamarin/xamarin-macios/issues/6486 for context. Note that we'll need to merge this PR before https://github.com/xamarin/xamarin-macios/pull/6797 can be merged. Thanks!