### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin
 obj
 *.userprefs
 
+/packages/
+.vs/


### PR DESCRIPTION
When I created #54, I accidentally committed the `.vs` cache directory, as well as the NuGet packages directory, which I then had to go back and amend away. I made this mistake because I thought the gitignore would exclude those directories. Now it does. 😄 