### PR TITLE
Bug 1003788: 10.14 missing from target Mac OS version drop-down menu

### DIFF
--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -39,8 +39,10 @@ namespace Xamarin.MacDev
 			MacOSXSdkVersion.V10_10,
 			MacOSXSdkVersion.V10_11,
 			MacOSXSdkVersion.V10_12,
-			MacOSXSdkVersion.V10_13
-		};
+			MacOSXSdkVersion.V10_13,
+            MacOSXSdkVersion.V10_14,
+            MacOSXSdkVersion.V10_15
+        };
 
 		static readonly Dictionary<string, DTSdkSettings> sdkSettingsCache = new Dictionary<string, DTSdkSettings> ();
 		static DTSettings dtSettings;

--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -40,8 +40,7 @@ namespace Xamarin.MacDev
 			MacOSXSdkVersion.V10_11,
 			MacOSXSdkVersion.V10_12,
 			MacOSXSdkVersion.V10_13,
-            MacOSXSdkVersion.V10_14,
-            MacOSXSdkVersion.V10_15
+            		MacOSXSdkVersion.V10_14
         };
 
 		static readonly Dictionary<string, DTSdkSettings> sdkSettingsCache = new Dictionary<string, DTSdkSettings> ();

--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -41,7 +41,7 @@ namespace Xamarin.MacDev
 			MacOSXSdkVersion.V10_12,
 			MacOSXSdkVersion.V10_13,
             		MacOSXSdkVersion.V10_14
-        };
+        	};
 
 		static readonly Dictionary<string, DTSdkSettings> sdkSettingsCache = new Dictionary<string, DTSdkSettings> ();
 		static DTSettings dtSettings;

--- a/Xamarin.MacDev/MacOSXSdkVersion.cs
+++ b/Xamarin.MacDev/MacOSXSdkVersion.cs
@@ -201,7 +201,7 @@ namespace Xamarin.MacDev
         	public static readonly MacOSXSdkVersion V10_14 = new MacOSXSdkVersion(10, 14);
 		public static readonly MacOSXSdkVersion V10_15 = new MacOSXSdkVersion(10, 15);
 
-        public static readonly MacOSXSdkVersion Cheetah = V10_0;
+        	public static readonly MacOSXSdkVersion Cheetah = V10_0;
 		public static readonly MacOSXSdkVersion Puma = V10_1;
 		public static readonly MacOSXSdkVersion Jaguar = V10_2;
 		public static readonly MacOSXSdkVersion Panther = V10_3;
@@ -218,7 +218,7 @@ namespace Xamarin.MacDev
         	public static readonly MacOSXSdkVersion Mojave = V10_14;
 		public static readonly MacOSXSdkVersion Catalina = V10_15;
 		
-        public static string VersionName (MacOSXSdkVersion version)
+        	public static string VersionName (MacOSXSdkVersion version)
 		{
 			string versionName;
 			switch (version.ToString ()) {

--- a/Xamarin.MacDev/MacOSXSdkVersion.cs
+++ b/Xamarin.MacDev/MacOSXSdkVersion.cs
@@ -198,8 +198,10 @@ namespace Xamarin.MacDev
 		public static readonly MacOSXSdkVersion V10_11 = new MacOSXSdkVersion (10, 11);
 		public static readonly MacOSXSdkVersion V10_12 = new MacOSXSdkVersion (10, 12);
 		public static readonly MacOSXSdkVersion V10_13 = new MacOSXSdkVersion (10, 13);
-		
-		public static readonly MacOSXSdkVersion Cheetah = V10_0;
+        public static readonly MacOSXSdkVersion V10_14 = new MacOSXSdkVersion(10, 14);
+        public static readonly MacOSXSdkVersion V10_15 = new MacOSXSdkVersion(10, 15);
+
+        public static readonly MacOSXSdkVersion Cheetah = V10_0;
 		public static readonly MacOSXSdkVersion Puma = V10_1;
 		public static readonly MacOSXSdkVersion Jaguar = V10_2;
 		public static readonly MacOSXSdkVersion Panther = V10_3;
@@ -213,8 +215,10 @@ namespace Xamarin.MacDev
 		public static readonly MacOSXSdkVersion ElCapitan = V10_11;
 		public static readonly MacOSXSdkVersion Sierra = V10_12;
 		public static readonly MacOSXSdkVersion HighSierra = V10_13;
+        public static readonly MacOSXSdkVersion Mojave = V10_14;
+        public static readonly MacOSXSdkVersion Catalina = V10_15;
 
-		public static string VersionName (MacOSXSdkVersion version)
+        public static string VersionName (MacOSXSdkVersion version)
 		{
 			string versionName;
 			switch (version.ToString ()) {

--- a/Xamarin.MacDev/MacOSXSdkVersion.cs
+++ b/Xamarin.MacDev/MacOSXSdkVersion.cs
@@ -214,9 +214,8 @@ namespace Xamarin.MacDev
 		public static readonly MacOSXSdkVersion ElCapitan = V10_11;
 		public static readonly MacOSXSdkVersion Sierra = V10_12;
 		public static readonly MacOSXSdkVersion HighSierra = V10_13;
-        public static readonly MacOSXSdkVersion Mojave = V10_14;
-        public static readonly MacOSXSdkVersion Catalina = V10_15;
-
+        	public static readonly MacOSXSdkVersion Mojave = V10_14;
+		
         public static string VersionName (MacOSXSdkVersion version)
 		{
 			string versionName;

--- a/Xamarin.MacDev/MacOSXSdkVersion.cs
+++ b/Xamarin.MacDev/MacOSXSdkVersion.cs
@@ -199,6 +199,7 @@ namespace Xamarin.MacDev
 		public static readonly MacOSXSdkVersion V10_12 = new MacOSXSdkVersion (10, 12);
 		public static readonly MacOSXSdkVersion V10_13 = new MacOSXSdkVersion (10, 13);
         	public static readonly MacOSXSdkVersion V10_14 = new MacOSXSdkVersion(10, 14);
+		public static readonly MacOSXSdkVersion V10_15 = new MacOSXSdkVersion(10, 15);
 
         public static readonly MacOSXSdkVersion Cheetah = V10_0;
 		public static readonly MacOSXSdkVersion Puma = V10_1;
@@ -215,6 +216,7 @@ namespace Xamarin.MacDev
 		public static readonly MacOSXSdkVersion Sierra = V10_12;
 		public static readonly MacOSXSdkVersion HighSierra = V10_13;
         	public static readonly MacOSXSdkVersion Mojave = V10_14;
+		public static readonly MacOSXSdkVersion Catalina = V10_15;
 		
         public static string VersionName (MacOSXSdkVersion version)
 		{

--- a/Xamarin.MacDev/MacOSXSdkVersion.cs
+++ b/Xamarin.MacDev/MacOSXSdkVersion.cs
@@ -198,8 +198,7 @@ namespace Xamarin.MacDev
 		public static readonly MacOSXSdkVersion V10_11 = new MacOSXSdkVersion (10, 11);
 		public static readonly MacOSXSdkVersion V10_12 = new MacOSXSdkVersion (10, 12);
 		public static readonly MacOSXSdkVersion V10_13 = new MacOSXSdkVersion (10, 13);
-        public static readonly MacOSXSdkVersion V10_14 = new MacOSXSdkVersion(10, 14);
-        public static readonly MacOSXSdkVersion V10_15 = new MacOSXSdkVersion(10, 15);
+        	public static readonly MacOSXSdkVersion V10_14 = new MacOSXSdkVersion(10, 14);
 
         public static readonly MacOSXSdkVersion Cheetah = V10_0;
 		public static readonly MacOSXSdkVersion Puma = V10_1;


### PR DESCRIPTION
Added 10.14 and 10.15 to list of Mac OS versions.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1003788/