### PR TITLE
Accept 'tools/buildinfo' as an alternative path to 'buildinfo' due to an nuget bug.

### DIFF
--- a/Xamarin.MacDev/MonoTouchSdk.cs
+++ b/Xamarin.MacDev/MonoTouchSdk.cs
@@ -285,8 +285,13 @@ namespace Xamarin.MacDev
 		ExtendedVersion extended_version;
 		public ExtendedVersion ExtendedVersion {
 			get {
-				if (extended_version == null)
+				if (extended_version == null) {
 					extended_version = ExtendedVersion.Read (Path.Combine (SdkDir, "buildinfo"));
+					if (extended_version == null) {
+						// 'buildinfo' doesn't work in a nuget package because of https://github.com/NuGet/Home/issues/8810, so use 'tools/buildinfo' instead.
+						extended_version = ExtendedVersion.Read (Path.Combine (SdkDir, "tools", "buildinfo"));
+					}
+				}
 				return extended_version;
 			}
 		}


### PR DESCRIPTION
nuget doesn't like files that start with 'build*' in the root nuget directory ([1]), which means we have to support finding the 'buildinfo' file somewhere else too (in particular in 'tools/buildinfo' instead).

[1]: https://github.com/NuGet/Home/issues/8810