### PR TITLE
[Xamarin.MacDev] Add interfaces to bridge Xamarin.iOS- and Xamarin.Mac-specific classes.

### DIFF
--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 
 namespace Xamarin.MacDev
 {
-	public abstract class AppleSdk
+	public abstract class AppleSdk : IAppleSdk
 	{
 		public string DeveloperRoot { get; protected set; }
 		public string VersionPlist { get; protected set; }
@@ -88,6 +88,11 @@ namespace Xamarin.MacDev
 		string GetSdkPlistFilename (string version, bool sim)
 		{
 			return Path.Combine (GetSdkPath (version, sim), "SDKSettings.plist");
+		}
+
+		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool is_simulator)
+		{
+			return SdkIsInstalled ((IPhoneSdkVersion) version, is_simulator);
 		}
 
 		public bool SdkIsInstalled (IPhoneSdkVersion version, bool sim)
@@ -161,6 +166,11 @@ namespace Xamarin.MacDev
 			});
 		}
 
+		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool is_simulator)
+		{
+			return GetClosestInstalledSdk ((IPhoneSdkVersion) version, is_simulator);
+		}
+
 		public IPhoneSdkVersion GetClosestInstalledSdk (IPhoneSdkVersion v, bool sim)
 		{
 			//sorted low to high, so get first that's >= requested version
@@ -169,6 +179,11 @@ namespace Xamarin.MacDev
 					return i;
 			}
 			return IPhoneSdkVersion.UseDefault;
+		}
+
+		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool is_simulator)
+		{
+			return GetInstalledSdkVersions (is_simulator).Cast<IAppleSdkVersion> ().ToArray ();
 		}
 
 		public IList<IPhoneSdkVersion> GetInstalledSdkVersions (bool sim)
@@ -226,6 +241,11 @@ namespace Xamarin.MacDev
 				return value.Value;
 
 			return null;
+		}
+
+		bool IAppleSdk.TryParseSdkVersion (string value, out IAppleSdkVersion version)
+		{
+			return IAppleSdkVersion_Extensions.TryParse<IPhoneSdkVersion> (value, out version);
 		}
 	}
 }

--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -90,9 +90,9 @@ namespace Xamarin.MacDev
 			return Path.Combine (GetSdkPath (version, sim), "SDKSettings.plist");
 		}
 
-		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool is_simulator)
+		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool isSimulator)
 		{
-			return SdkIsInstalled ((IPhoneSdkVersion) version, is_simulator);
+			return SdkIsInstalled ((IPhoneSdkVersion) version, isSimulator);
 		}
 
 		public bool SdkIsInstalled (IPhoneSdkVersion version, bool sim)
@@ -166,9 +166,9 @@ namespace Xamarin.MacDev
 			});
 		}
 
-		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool is_simulator)
+		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool isSimulator)
 		{
-			return GetClosestInstalledSdk ((IPhoneSdkVersion) version, is_simulator);
+			return GetClosestInstalledSdk ((IPhoneSdkVersion) version, isSimulator);
 		}
 
 		public IPhoneSdkVersion GetClosestInstalledSdk (IPhoneSdkVersion v, bool sim)
@@ -181,9 +181,9 @@ namespace Xamarin.MacDev
 			return IPhoneSdkVersion.UseDefault;
 		}
 
-		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool is_simulator)
+		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool isSimulator)
 		{
-			return GetInstalledSdkVersions (is_simulator).Cast<IAppleSdkVersion> ().ToArray ();
+			return GetInstalledSdkVersions (isSimulator).Cast<IAppleSdkVersion> ().ToArray ();
 		}
 
 		public IList<IPhoneSdkVersion> GetInstalledSdkVersions (bool sim)

--- a/Xamarin.MacDev/IAppleSdk.cs
+++ b/Xamarin.MacDev/IAppleSdk.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Xamarin.MacDev {
+	public interface IAppleSdk {
+		bool IsInstalled { get; }
+		string DeveloperRoot { get; }
+		string GetPlatformPath (bool is_simulator);
+		string GetSdkPath (string version, bool is_simulator);
+		bool SdkIsInstalled (IAppleSdkVersion version, bool is_simulator);
+		bool TryParseSdkVersion (string value, out IAppleSdkVersion version);
+		IAppleSdkVersion GetClosestInstalledSdk (IAppleSdkVersion version, bool is_simulator);
+		IList<IAppleSdkVersion> GetInstalledSdkVersions (bool is_simulator);
+	}
+}

--- a/Xamarin.MacDev/IAppleSdk.cs
+++ b/Xamarin.MacDev/IAppleSdk.cs
@@ -5,11 +5,11 @@ namespace Xamarin.MacDev {
 	public interface IAppleSdk {
 		bool IsInstalled { get; }
 		string DeveloperRoot { get; }
-		string GetPlatformPath (bool is_simulator);
-		string GetSdkPath (string version, bool is_simulator);
-		bool SdkIsInstalled (IAppleSdkVersion version, bool is_simulator);
+		string GetPlatformPath (bool isSimulator);
+		string GetSdkPath (string version, bool isSimulator);
+		bool SdkIsInstalled (IAppleSdkVersion version, bool isSimulator);
 		bool TryParseSdkVersion (string value, out IAppleSdkVersion version);
-		IAppleSdkVersion GetClosestInstalledSdk (IAppleSdkVersion version, bool is_simulator);
-		IList<IAppleSdkVersion> GetInstalledSdkVersions (bool is_simulator);
+		IAppleSdkVersion GetClosestInstalledSdk (IAppleSdkVersion version, bool isSimulator);
+		IList<IAppleSdkVersion> GetInstalledSdkVersions (bool isSimulator);
 	}
 }

--- a/Xamarin.MacDev/IAppleSdkVersion.cs
+++ b/Xamarin.MacDev/IAppleSdkVersion.cs
@@ -1,0 +1,49 @@
+using System;
+namespace Xamarin.MacDev {
+	public interface IAppleSdkVersion : IEquatable<IAppleSdkVersion> {
+		bool IsUseDefault { get; }
+		void SetVersion (int [] version);
+		IAppleSdkVersion GetUseDefault ();
+	}
+
+	public static class IAppleSdkVersion_Extensions {
+		public static IAppleSdkVersion ResolveIfDefault (this IAppleSdkVersion @this, IAppleSdk sdk, bool sim)
+		{
+			return @this.IsUseDefault ? @this.GetDefault (sdk, sim) : @this;
+		}
+
+		public static IAppleSdkVersion GetDefault (this IAppleSdkVersion @this, IAppleSdk sdk, bool sim)
+		{
+			var v = sdk.GetInstalledSdkVersions (sim);
+			return v.Count > 0 ? v [v.Count - 1] : @this.GetUseDefault ();
+		}
+
+		public static bool TryParse<T> (string s, out T result) where T : IAppleSdkVersion, new()
+		{
+			result = new T ();
+			if (s == null)
+				return false;
+
+			var vstr = s.Split ('.');
+			var vint = new int [vstr.Length];
+
+			for (int j = 0; j < vstr.Length; j++) {
+				int component;
+				if (!int.TryParse (vstr [j], out component))
+					return false;
+
+				vint [j] = component;
+			}
+
+			result.SetVersion (vint);
+			return true;
+		}
+
+		public static bool TryParse<T> (string s, out IAppleSdkVersion result) where T : IAppleSdkVersion, new()
+		{
+			var rv = TryParse<T> (s, out T tmp);
+			result = tmp;
+			return rv;
+		}
+	}
+}

--- a/Xamarin.MacDev/IPhoneSdkVersion.cs
+++ b/Xamarin.MacDev/IPhoneSdkVersion.cs
@@ -29,7 +29,7 @@ using System;
 
 namespace Xamarin.MacDev
 {
-	public struct IPhoneSdkVersion : IComparable<IPhoneSdkVersion>, IEquatable<IPhoneSdkVersion>
+	public struct IPhoneSdkVersion : IComparable<IPhoneSdkVersion>, IEquatable<IPhoneSdkVersion>, IAppleSdkVersion
 	{
 		int[] version;
 
@@ -57,6 +57,11 @@ namespace Xamarin.MacDev
 			this.version = version;
 		}
 		
+		void IAppleSdkVersion.SetVersion (int[] version)
+		{
+			this.version = version;
+		}
+
 		public static IPhoneSdkVersion Parse (string s)
 		{
 			var vstr = s.Split ('.');
@@ -70,24 +75,7 @@ namespace Xamarin.MacDev
 		
 		public static bool TryParse (string s, out IPhoneSdkVersion result)
 		{
-			result = new IPhoneSdkVersion ();
-
-			if (s == null)
-				return false;
-
-			var vstr = s.Split ('.');
-			var vint = new int[vstr.Length];
-
-			for (int j = 0; j < vstr.Length; j++) {
-				int component;
-				if (!int.TryParse (vstr[j], out component))
-					return false;
-
-				vint[j] = component;
-			}
-
-			result.version = vint;
-			return true;
+			return IAppleSdkVersion_Extensions.TryParse<IPhoneSdkVersion> (s, out result);
 		}
 		
 		public int[] Version { get { return version; } }
@@ -145,6 +133,11 @@ namespace Xamarin.MacDev
 			return false;
 		}
 		
+		bool IEquatable<IAppleSdkVersion>.Equals (IAppleSdkVersion other)
+		{
+			return Equals ((object) other);
+		}
+
 		public override int GetHashCode ()
 		{
 			unchecked {
@@ -188,6 +181,11 @@ namespace Xamarin.MacDev
 		
 		public bool IsUseDefault {
 			get { return version == null || version.Length == 0; }
+		}
+
+		IAppleSdkVersion IAppleSdkVersion.GetUseDefault ()
+		{
+			return UseDefault;
 		}
 
 #if !WINDOWS

--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -134,7 +134,7 @@ namespace Xamarin.MacDev
 			return DesktopPlatform;
 		}
 
-		string IAppleSdk.GetPlatformPath (bool is_simulator)
+		string IAppleSdk.GetPlatformPath (bool isSimulator)
 		{
 			return GetPlatformPath ();
 		}
@@ -149,7 +149,7 @@ namespace Xamarin.MacDev
 			return Path.Combine (SdkDeveloperRoot, "SDKs", "MacOSX" + version + ".sdk");
 		}
 
-		string IAppleSdk.GetSdkPath (string version, bool is_simulator)
+		string IAppleSdk.GetSdkPath (string version, bool isSimulator)
 		{
 			return GetSdkPath (version);
 		}
@@ -159,7 +159,7 @@ namespace Xamarin.MacDev
 			return Path.Combine (GetSdkPath (version), "SDKSettings.plist");
 		}
 
-		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool is_simulator)
+		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool isSimulator)
 		{
 			return SdkIsInstalled ((MacOSXSdkVersion) version);
 		}
@@ -246,7 +246,7 @@ namespace Xamarin.MacDev
 			return null;
 		}
 			
-		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool is_simulator)
+		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool isSimulator)
 		{
 			return GetClosestInstalledSdk ((MacOSXSdkVersion) version);
 		}
@@ -261,7 +261,7 @@ namespace Xamarin.MacDev
 			return MacOSXSdkVersion.UseDefault;
 		}
 		
-		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool is_simulator)
+		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool isSimulator)
 		{
 			return GetInstalledSdkVersions ().Cast<IAppleSdkVersion> ().ToArray ();
 		}

--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 
 namespace Xamarin.MacDev
 {
-	public class MacOSXSdk
+	public class MacOSXSdk : IAppleSdk
 	{
 		List<MacOSXSdkVersion> knownOSVersions = new List<MacOSXSdkVersion> {
 			MacOSXSdkVersion.V10_7,
@@ -133,6 +133,11 @@ namespace Xamarin.MacDev
 		{
 			return DesktopPlatform;
 		}
+
+		string IAppleSdk.GetPlatformPath (bool is_simulator)
+		{
+			return GetPlatformPath ();
+		}
 		
 		public string GetSdkPath (MacOSXSdkVersion version)
 		{
@@ -143,12 +148,22 @@ namespace Xamarin.MacDev
 		{
 			return Path.Combine (SdkDeveloperRoot, "SDKs", "MacOSX" + version + ".sdk");
 		}
-		
+
+		string IAppleSdk.GetSdkPath (string version, bool is_simulator)
+		{
+			return GetSdkPath (version);
+		}
+
 		string GetSdkPlistFilename (string version)
 		{
 			return Path.Combine (GetSdkPath (version), "SDKSettings.plist");
 		}
-		
+
+		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool is_simulator)
+		{
+			return SdkIsInstalled ((MacOSXSdkVersion) version);
+		}
+
 		public bool SdkIsInstalled (MacOSXSdkVersion version)
 		{
 			foreach (var v in InstalledSdkVersions) {
@@ -231,6 +246,11 @@ namespace Xamarin.MacDev
 			return null;
 		}
 			
+		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool is_simulator)
+		{
+			return GetClosestInstalledSdk ((MacOSXSdkVersion) version);
+		}
+
 		public MacOSXSdkVersion GetClosestInstalledSdk (MacOSXSdkVersion v)
 		{
 			// sorted low to high, so get first that's >= requested version
@@ -241,11 +261,21 @@ namespace Xamarin.MacDev
 			return MacOSXSdkVersion.UseDefault;
 		}
 		
+		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool is_simulator)
+		{
+			return GetInstalledSdkVersions ().Cast<IAppleSdkVersion> ().ToArray ();
+		}
+
 		public IList<MacOSXSdkVersion> GetInstalledSdkVersions ()
 		{
 			return InstalledSdkVersions;
 		}
 		
+		bool IAppleSdk.TryParseSdkVersion (string value, out IAppleSdkVersion version)
+		{
+			return IAppleSdkVersion_Extensions.TryParse<MacOSXSdkVersion> (value, out version);
+		}
+
 		public class DTSettings
 		{
 			public string DTXcodeBuild { get; set; }

--- a/Xamarin.MacDev/MacOSXSdkVersion.cs
+++ b/Xamarin.MacDev/MacOSXSdkVersion.cs
@@ -27,7 +27,7 @@ using System;
 
 namespace Xamarin.MacDev
 {
-	public struct MacOSXSdkVersion : IComparable<MacOSXSdkVersion>, IEquatable<MacOSXSdkVersion>
+	public struct MacOSXSdkVersion : IComparable<MacOSXSdkVersion>, IEquatable<MacOSXSdkVersion>, IAppleSdkVersion
 	{
 		int[] version;
 		
@@ -35,6 +35,11 @@ namespace Xamarin.MacDev
 		{
 			if (version == null)
 				throw new ArgumentNullException ();
+			this.version = version;
+		}
+
+		void IAppleSdkVersion.SetVersion (int [] version)
+		{
 			this.version = version;
 		}
 
@@ -56,19 +61,7 @@ namespace Xamarin.MacDev
 		
 		public static bool TryParse (string s, out MacOSXSdkVersion result)
 		{
-			result = new MacOSXSdkVersion ();
-			if (s == null)
-				return false;
-			var vstr = s.Split ('.');
-			var vint = new int[vstr.Length];
-			for (int j = 0; j < vstr.Length; j++) {
-				int component;
-				if (!int.TryParse (vstr[j], out component))
-					return false;
-				vint[j] = component;
-			}
-			result.version = vint;
-			return true;
+			return IAppleSdkVersion_Extensions.TryParse<MacOSXSdkVersion> (s, out result);
 		}
 		
 		public int[] Version { get { return version; } }
@@ -124,6 +117,11 @@ namespace Xamarin.MacDev
 			return false;
 		}
 		
+		bool IEquatable<IAppleSdkVersion>.Equals (IAppleSdkVersion other)
+		{
+			return Equals ((object) other);
+		}
+
 		public override int GetHashCode ()
 		{
 			unchecked {
@@ -169,6 +167,16 @@ namespace Xamarin.MacDev
 			get {
 				return version == null || version.Length == 0;
 			}
+		}
+
+		IAppleSdkVersion IAppleSdkVersion.GetUseDefault ()
+		{
+			return UseDefault;
+		}
+
+		public static MacOSXSdkVersion GetDefault (IAppleSdk sdk)
+		{
+			return GetDefault ((MacOSXSdk) sdk);
 		}
 
 		public static MacOSXSdkVersion GetDefault (MacOSXSdk sdk)


### PR DESCRIPTION
* Add IAppleSdk interface to bridge AppleSdk and MacOSXSdk.
* Add IAppleSdkVersion interface to bridge IPhoneSdkVersion and MacOXSdkVersion.