### PR TITLE
Add AutoFill CredentialProvider NSExtensionPoint support

### DIFF
--- a/Xamarin.MacDev/ManifestExtensions.cs
+++ b/Xamarin.MacDev/ManifestExtensions.cs
@@ -889,6 +889,6 @@ namespace Xamarin.MacDev
 		//com.apple.spotlight.index
 		SpotlightIndex,
 		// com.apple.authentication-services-credential-provider-ui
-		AuthenticationServicesCredentialProviderUI
+		AuthenticationServicesCredentialProviderUI,
 	}
 }

--- a/Xamarin.MacDev/ManifestExtensions.cs
+++ b/Xamarin.MacDev/ManifestExtensions.cs
@@ -454,6 +454,8 @@ namespace Xamarin.MacDev
 				return IOSExtensionPoint.SharedLinks;
 			case "com.apple.spotlight.index":
 				return IOSExtensionPoint.SpotlightIndex;
+			case "com.apple.authentication-services-credential-provider-ui":
+				return IOSExtensionPoint.AuthenticationServicesCredentialProviderUI;
 			}
 
 			return IOSExtensionPoint.Unknown;
@@ -885,6 +887,8 @@ namespace Xamarin.MacDev
 		//com.apple.Safari.sharedlinks-service
 		SharedLinks,
 		//com.apple.spotlight.index
-		SpotlightIndex
+		SpotlightIndex,
+		// com.apple.authentication-services-credential-provider-ui
+		AuthenticationServicesCredentialProviderUI
 	}
 }

--- a/Xamarin.MacDev/MonoTouchSdk.cs
+++ b/Xamarin.MacDev/MonoTouchSdk.cs
@@ -157,6 +157,7 @@ namespace Xamarin.MacDev
 			ios.Add ("com.apple.message-payload-provider", new PString ("10.0"));
 			ios.Add ("com.apple.usernotifications.content-extension", new PString ("10.0"));
 			ios.Add ("com.apple.usernotifications.service", new PString ("10.0"));
+			ios.Add ("com.apple.authentication-services-credential-provider-ui", new PString ("12.0"));
 
 			tvos.Add ("com.apple.broadcast-services", new PString ("10.0"));
 			tvos.Add ("com.apple.tv-services", new PString ("9.0"));


### PR DESCRIPTION
These commits add support for AutoFill Credential Provider extensions to be built.  A related change to Xamarin.macios is also pending approval of this request.    For more information, see posted issue at: https://github.com/xamarin/xamarin-macios/issues/9000