### PR TITLE
[xcode12] Adds Accent Color manifest keys

### DIFF
--- a/Xamarin.MacDev/ManifestExtensions.cs
+++ b/Xamarin.MacDev/ManifestExtensions.cs
@@ -799,6 +799,8 @@ namespace Xamarin.MacDev
 
 		public const string XSAppIconAssets = "XSAppIconAssets";
 		public const string XSLaunchImageAssets = "XSLaunchImageAssets";
+		public const string XSAccentColorAssets = "XSAccentColorAssets";
+		public const string NSAccentColorName = "NSAccentColorName";
 		
 		public const string MapKitDirections = "MKDirectionsApplicationSupportedModes";
 


### PR DESCRIPTION
XSAccentColorAssets will be used as custom key for storing the path to the asset, and NSAccentColorName is the Apple key that contains the name of the asset that will be used as accent color by the OS