### PR TITLE
Use what's returned by 'xcode-select -p' as the configured Xcode if none is specified in Visual Studio's settings.

### DIFF
--- a/Xamarin.MacDev/Xamarin.MacDev.csproj
+++ b/Xamarin.MacDev/Xamarin.MacDev.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net451;net461;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">


### PR DESCRIPTION
Use what's returned by 'xcode-select -p' as the configured Xcode if none is
specified in Visual Studio's settings. It looks like this was the intention in
the code, but the code that calls 'xcode-select -p' would never execute,
because we'd only run into it if GetConfiguredSdkLocation returned null/empty,
which it never did because it returned the default location
'/Applications/Xcode.app' if nothing was configured in VSfM. With this change,
GetConfiguredSdkLocation will try to get the system's Xcode location
('xcode-select -p') before returning /Applications/Xcode.app.

Also remove /Developer as a default location, Xcode hasn't been there in many,
many years.

Now the order is:

1. Settings in Visual Studio's Preferences.
2. System's Xcode (xcode-select --print-path).
3. /Applications/Xcode.app

This avoids strange problems if the system's Xcode is not
/Applications/Xcode.app and there's no Xcode configured in Visual Studio's
settings.

Ref: https://github.com/xamarin/xamarin-macios/issues/10003