### PR TITLE
[Xamarin.MacDev] Add GetAppleDTSettings and GetSdkSettings to the IAppleSdk interface.

### DIFF
--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -105,6 +105,11 @@ namespace Xamarin.MacDev
 
 		public AppleDTSdkSettings GetSdkSettings (IPhoneSdkVersion sdk, bool isSim)
 		{
+			return GetSdkSettings ((IAppleSdkVersion) sdk, isSim);
+		}
+
+		public AppleDTSdkSettings GetSdkSettings (IAppleSdkVersion sdk, bool isSim)
+		{
 			var cache = isSim ? simSettingsCache : sdkSettingsCache;
 
 			AppleDTSdkSettings settings;
@@ -122,7 +127,7 @@ namespace Xamarin.MacDev
 			return settings;
 		}
 
-		AppleDTSdkSettings LoadSdkSettings (IPhoneSdkVersion sdk, bool isSim)
+		AppleDTSdkSettings LoadSdkSettings (IAppleSdkVersion sdk, bool isSim)
 		{
 			var settings = new AppleDTSdkSettings ();
 
@@ -164,6 +169,11 @@ namespace Xamarin.MacDev
 				DTXcodeBuild = GrabRootString (VersionPlist, "ProductBuildVersion"),
 				BuildMachineOSBuild = GrabRootString (systemVersionPlist, "ProductBuildVersion"),
 			});
+		}
+
+		public AppleDTSettings GetAppleDTSettings ()
+		{
+			return GetDTSettings ();
 		}
 
 		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool isSimulator)

--- a/Xamarin.MacDev/IAppleSdk.cs
+++ b/Xamarin.MacDev/IAppleSdk.cs
@@ -11,5 +11,7 @@ namespace Xamarin.MacDev {
 		bool TryParseSdkVersion (string value, out IAppleSdkVersion version);
 		IAppleSdkVersion GetClosestInstalledSdk (IAppleSdkVersion version, bool isSimulator);
 		IList<IAppleSdkVersion> GetInstalledSdkVersions (bool isSimulator);
+		AppleDTSettings GetAppleDTSettings ();
+		AppleDTSdkSettings GetSdkSettings (IAppleSdkVersion version, bool isSimulator);
 	}
 }


### PR DESCRIPTION
And make the MacOSXSdk and AppleSdk classes implement these new methods,
without changing any of the public API in these classes.

This makes it easier to share code between Xamarin.iOS and Xamarin.Mac, since
the IAppleSdk interface can be used in shared code, while the separate classes
can't.