### PR TITLE
[Xamarin.MacDev] Fail gracefully if trying to grab a PList entry from a file that doesn't exist.

### DIFF
--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -270,6 +270,9 @@ namespace Xamarin.MacDev
 		
 		static string GrabRootString (string file, string key)
 		{
+			if (!File.Exists (file))
+				return null;
+
 			var dict = PDictionary.FromFile (file);
 			PString value;
 


### PR DESCRIPTION
We run into this code path on Mac Catalyst.