### PR TITLE
[Xamarin.MacDev] Add an AppleSdkVersion struct which replaces IPhoneSdkVersion and MacOSXSdkVersion.

### DIFF
--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -42,8 +42,8 @@ namespace Xamarin.MacDev
 		public string SimPlatform { get { return Path.Combine (DeveloperRoot, "Platforms/" + SimulatorPlatformName + ".platform"); } }
 
 		public bool IsInstalled { get; private set; }
-		public IPhoneSdkVersion[] InstalledSdkVersions { get; private set; }
-		public IPhoneSdkVersion[] InstalledSimVersions { get; private set; }
+		public AppleSdkVersion[] InstalledSdkVersions { get; private set; }
+		public AppleSdkVersion[] InstalledSimVersions { get; private set; }
 
 		readonly Dictionary<string, AppleDTSdkSettings> sdkSettingsCache = new Dictionary<string, AppleDTSdkSettings> ();
 		readonly Dictionary<string, AppleDTSdkSettings> simSettingsCache = new Dictionary<string, AppleDTSdkSettings> ();
@@ -61,8 +61,8 @@ namespace Xamarin.MacDev
 				InstalledSdkVersions = EnumerateSdks (Path.Combine (DevicePlatform, "Developer/SDKs"), DevicePlatformName);
 				InstalledSimVersions = EnumerateSdks (Path.Combine (SimPlatform, "Developer/SDKs"), SimulatorPlatformName);
 			} else {
-				InstalledSdkVersions = new IPhoneSdkVersion[0];
-				InstalledSimVersions = new IPhoneSdkVersion[0];
+				InstalledSdkVersions = new AppleSdkVersion [0];
+				InstalledSimVersions = new AppleSdkVersion [0];
 			}
 		}
 
@@ -72,7 +72,7 @@ namespace Xamarin.MacDev
 			return sim ? SimPlatform : DevicePlatform;
 		}
 
-		public string GetSdkPath (IPhoneSdkVersion version, bool sim)
+		public string GetSdkPath (IAppleSdkVersion version, bool sim)
 		{
 			return GetSdkPath (version.ToString (), sim);
 		}
@@ -92,10 +92,10 @@ namespace Xamarin.MacDev
 
 		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool isSimulator)
 		{
-			return SdkIsInstalled ((IPhoneSdkVersion) version, isSimulator);
+			return SdkIsInstalled ((AppleSdkVersion) version, isSimulator);
 		}
 
-		public bool SdkIsInstalled (IPhoneSdkVersion version, bool sim)
+		public bool SdkIsInstalled (AppleSdkVersion version, bool sim)
 		{
 			foreach (var v in (sim? InstalledSimVersions : InstalledSdkVersions))
 				if (v.Equals (version))
@@ -103,7 +103,7 @@ namespace Xamarin.MacDev
 			return false;
 		}
 
-		public AppleDTSdkSettings GetSdkSettings (IPhoneSdkVersion sdk, bool isSim)
+		public AppleDTSdkSettings GetSdkSettings (AppleSdkVersion sdk, bool isSim)
 		{
 			return GetSdkSettings ((IAppleSdkVersion) sdk, isSim);
 		}
@@ -178,17 +178,17 @@ namespace Xamarin.MacDev
 
 		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool isSimulator)
 		{
-			return GetClosestInstalledSdk ((IPhoneSdkVersion) version, isSimulator);
+			return GetClosestInstalledSdk ((AppleSdkVersion) version, isSimulator);
 		}
 
-		public IPhoneSdkVersion GetClosestInstalledSdk (IPhoneSdkVersion v, bool sim)
+		public AppleSdkVersion GetClosestInstalledSdk (AppleSdkVersion v, bool sim)
 		{
 			//sorted low to high, so get first that's >= requested version
 			foreach (var i in GetInstalledSdkVersions (sim)) {
 				if (i.CompareTo (v) >= 0)
 					return i;
 			}
-			return IPhoneSdkVersion.UseDefault;
+			return AppleSdkVersion.UseDefault;
 		}
 
 		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool isSimulator)
@@ -196,15 +196,15 @@ namespace Xamarin.MacDev
 			return GetInstalledSdkVersions (isSimulator).Cast<IAppleSdkVersion> ().ToArray ();
 		}
 
-		public IList<IPhoneSdkVersion> GetInstalledSdkVersions (bool sim)
+		public IList<AppleSdkVersion> GetInstalledSdkVersions (bool sim)
 		{
 			return sim ? InstalledSimVersions : InstalledSdkVersions;
 		}
 
-		protected static IPhoneSdkVersion[] EnumerateSdks (string sdkDir, string name)
+		protected static AppleSdkVersion [] EnumerateSdks (string sdkDir, string name)
 		{
 			if (!Directory.Exists (sdkDir))
-				return new IPhoneSdkVersion[0];
+				return new AppleSdkVersion [0];
 
 			var sdks = new List<string> ();
 
@@ -225,10 +225,10 @@ namespace Xamarin.MacDev
 					sdks.Add (d);
 			}
 
-			var vs = new List<IPhoneSdkVersion> ();
+			var vs = new List<AppleSdkVersion> ();
 			foreach (var s in sdks) {
 				try {
-					vs.Add (IPhoneSdkVersion.Parse (s));
+					vs.Add (AppleSdkVersion.Parse (s));
 				} catch (Exception ex) {
 					LoggingService.LogError ("Could not parse {0} SDK version '{1}':\n{2}", name, s, ex.ToString ());
 				}
@@ -255,7 +255,7 @@ namespace Xamarin.MacDev
 
 		bool IAppleSdk.TryParseSdkVersion (string value, out IAppleSdkVersion version)
 		{
-			return IAppleSdkVersion_Extensions.TryParse<IPhoneSdkVersion> (value, out version);
+			return IAppleSdkVersion_Extensions.TryParse<AppleSdkVersion> (value, out version);
 		}
 	}
 }

--- a/Xamarin.MacDev/AppleSdkVersion.cs
+++ b/Xamarin.MacDev/AppleSdkVersion.cs
@@ -1,0 +1,214 @@
+//
+// AppleSdkVersion.cs
+//
+// Authors: Michael Hutchinson <mhutchinson@novell.com>
+//          Jeffrey Stedfast <jeff@xamarin.com>
+//
+// Copyright (c) 2010 Novell, Inc. (http://www.novell.com)
+// Copyright (c) 2011-2013 Xamarin Inc. (http://www.xamarin.com)
+// Copyright (c) 2021 Microsoft Corp. (http://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace Xamarin.MacDev {
+	public struct AppleSdkVersion : IComparable<AppleSdkVersion>, IEquatable<AppleSdkVersion>, IAppleSdkVersion {
+		int [] version;
+
+		public AppleSdkVersion (Version version)
+		{
+			if (version == null)
+				throw new ArgumentNullException ();
+
+			if (version.Build != -1) {
+				this.version = new int [3];
+				this.version [2] = version.Build;
+			} else {
+				this.version = new int [2];
+			}
+
+			this.version [0] = version.Major;
+			this.version [1] = version.Minor;
+		}
+
+		public AppleSdkVersion (params int [] version)
+		{
+			if (version == null)
+				throw new ArgumentNullException (nameof (version));
+
+			this.version = version;
+		}
+
+		void IAppleSdkVersion.SetVersion (int [] version)
+		{
+			this.version = version;
+		}
+
+		public static AppleSdkVersion Parse (string s)
+		{
+			return IAppleSdkVersion_Extensions.Parse<AppleSdkVersion> (s);
+		}
+
+		public static bool TryParse (string s, out AppleSdkVersion result)
+		{
+			return IAppleSdkVersion_Extensions.TryParse (s, out result);
+		}
+
+		public int [] Version { get { return version; } }
+
+		public override string ToString ()
+		{
+			return IAppleSdkVersion_Extensions.ToString (this);
+		}
+
+		public int CompareTo (AppleSdkVersion other)
+		{
+			return IAppleSdkVersion_Extensions.CompareTo (this, other);
+		}
+
+		public int CompareTo (IAppleSdkVersion other)
+		{
+			return IAppleSdkVersion_Extensions.CompareTo (this, other);
+		}
+
+		public bool Equals (IAppleSdkVersion other)
+		{
+			return IAppleSdkVersion_Extensions.Equals (this, other);
+		}
+
+		public bool Equals (AppleSdkVersion other)
+		{
+			return IAppleSdkVersion_Extensions.Equals (this, other);
+		}
+
+		public override bool Equals (object obj)
+		{
+			return IAppleSdkVersion_Extensions.Equals (this, obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			return IAppleSdkVersion_Extensions.GetHashCode (this);
+		}
+
+		public static bool operator == (AppleSdkVersion a, IAppleSdkVersion b)
+		{
+			return a.Equals (b);
+		}
+
+		public static bool operator != (AppleSdkVersion a, IAppleSdkVersion b)
+		{
+			return !a.Equals (b);
+		}
+
+		public static bool operator < (AppleSdkVersion a, IAppleSdkVersion b)
+		{
+			return a.CompareTo (b) < 0;
+		}
+
+		public static bool operator > (AppleSdkVersion a, IAppleSdkVersion b)
+		{
+			return a.CompareTo (b) > 0;
+		}
+
+		public static bool operator <= (AppleSdkVersion a, IAppleSdkVersion b)
+		{
+			return a.CompareTo (b) <= 0;
+		}
+
+		public static bool operator >= (AppleSdkVersion a, IAppleSdkVersion b)
+		{
+			return a.CompareTo (b) >= 0;
+		}
+
+		public bool IsUseDefault {
+			get { return version == null || version.Length == 0; }
+		}
+
+		IAppleSdkVersion IAppleSdkVersion.GetUseDefault ()
+		{
+			return UseDefault;
+		}
+
+#if !WINDOWS
+		public AppleSdkVersion ResolveIfDefault (AppleSdk sdk, bool sim)
+		{
+			return IsUseDefault ? GetDefault (sdk, sim) : this;
+		}
+
+		public static AppleSdkVersion GetDefault (AppleSdk sdk, bool sim)
+		{
+			var v = sdk.GetInstalledSdkVersions (sim);
+			return v.Count > 0 ? v [v.Count - 1] : UseDefault;
+		}
+#endif
+
+		public static readonly AppleSdkVersion UseDefault = new AppleSdkVersion (new int [0]);
+
+		public static readonly AppleSdkVersion V1_0 = new AppleSdkVersion (1, 0);
+		public static readonly AppleSdkVersion V2_0 = new AppleSdkVersion (2, 0);
+		public static readonly AppleSdkVersion V2_1 = new AppleSdkVersion (2, 1);
+		public static readonly AppleSdkVersion V2_2 = new AppleSdkVersion (2, 2);
+		public static readonly AppleSdkVersion V3_0 = new AppleSdkVersion (3, 0);
+		public static readonly AppleSdkVersion V3_1 = new AppleSdkVersion (3, 1);
+		public static readonly AppleSdkVersion V3_2 = new AppleSdkVersion (3, 2);
+		public static readonly AppleSdkVersion V3_99 = new AppleSdkVersion (3, 99);
+		public static readonly AppleSdkVersion V4_0 = new AppleSdkVersion (4, 0);
+		public static readonly AppleSdkVersion V4_1 = new AppleSdkVersion (4, 1);
+		public static readonly AppleSdkVersion V4_2 = new AppleSdkVersion (4, 2);
+		public static readonly AppleSdkVersion V4_3 = new AppleSdkVersion (4, 3);
+		public static readonly AppleSdkVersion V5_0 = new AppleSdkVersion (5, 0);
+		public static readonly AppleSdkVersion V5_1 = new AppleSdkVersion (5, 1);
+		public static readonly AppleSdkVersion V5_1_1 = new AppleSdkVersion (5, 1, 1);
+		public static readonly AppleSdkVersion V5_2 = new AppleSdkVersion (5, 2);
+		public static readonly AppleSdkVersion V6_0 = new AppleSdkVersion (6, 0);
+		public static readonly AppleSdkVersion V6_1 = new AppleSdkVersion (6, 1);
+		public static readonly AppleSdkVersion V6_2 = new AppleSdkVersion (6, 2);
+		public static readonly AppleSdkVersion V7_0 = new AppleSdkVersion (7, 0);
+		public static readonly AppleSdkVersion V7_1 = new AppleSdkVersion (7, 1);
+		public static readonly AppleSdkVersion V7_2_1 = new AppleSdkVersion (7, 2, 1);
+		public static readonly AppleSdkVersion V8_0 = new AppleSdkVersion (8, 0);
+		public static readonly AppleSdkVersion V8_1 = new AppleSdkVersion (8, 1);
+		public static readonly AppleSdkVersion V8_2 = new AppleSdkVersion (8, 2);
+		public static readonly AppleSdkVersion V8_3 = new AppleSdkVersion (8, 3);
+		public static readonly AppleSdkVersion V8_4 = new AppleSdkVersion (8, 4);
+		public static readonly AppleSdkVersion V9_0 = new AppleSdkVersion (9, 0);
+		public static readonly AppleSdkVersion V9_1 = new AppleSdkVersion (9, 1);
+		public static readonly AppleSdkVersion V9_2 = new AppleSdkVersion (9, 2);
+		public static readonly AppleSdkVersion V9_3 = new AppleSdkVersion (9, 3);
+		public static readonly AppleSdkVersion V10_0 = new AppleSdkVersion (10, 0);
+		public static readonly AppleSdkVersion V10_1 = new AppleSdkVersion (10, 1);
+		public static readonly AppleSdkVersion V10_2 = new AppleSdkVersion (10, 2);
+		public static readonly AppleSdkVersion V10_3 = new AppleSdkVersion (10, 3);
+		public static readonly AppleSdkVersion V10_4 = new AppleSdkVersion (10, 4);
+		public static readonly AppleSdkVersion V10_5 = new AppleSdkVersion (10, 5);
+		public static readonly AppleSdkVersion V10_6 = new AppleSdkVersion (10, 6);
+		public static readonly AppleSdkVersion V10_7 = new AppleSdkVersion (10, 7);
+		public static readonly AppleSdkVersion V10_8 = new AppleSdkVersion (10, 8);
+		public static readonly AppleSdkVersion V10_9 = new AppleSdkVersion (10, 9);
+		public static readonly AppleSdkVersion V10_10 = new AppleSdkVersion (10, 10);
+		public static readonly AppleSdkVersion V10_11 = new AppleSdkVersion (10, 11);
+		public static readonly AppleSdkVersion V10_12 = new AppleSdkVersion (10, 12);
+		public static readonly AppleSdkVersion V10_13 = new AppleSdkVersion (10, 13);
+		public static readonly AppleSdkVersion V10_14 = new AppleSdkVersion (10, 14);
+		public static readonly AppleSdkVersion V10_15 = new AppleSdkVersion (10, 15);
+		public static readonly AppleSdkVersion V11_0 = new AppleSdkVersion (11, 0);
+	}
+}

--- a/Xamarin.MacDev/IAppleSdkVersion.cs
+++ b/Xamarin.MacDev/IAppleSdkVersion.cs
@@ -4,6 +4,7 @@ namespace Xamarin.MacDev {
 		bool IsUseDefault { get; }
 		void SetVersion (int [] version);
 		IAppleSdkVersion GetUseDefault ();
+		int [] Version { get; }
 	}
 
 	public static class IAppleSdkVersion_Extensions {
@@ -57,6 +58,88 @@ namespace Xamarin.MacDev {
 			var rv = TryParse<T> (s, out T tmp);
 			result = tmp;
 			return rv;
+		}
+
+		public static T Parse<T> (string s) where T: IAppleSdkVersion, new()
+		{
+			var vstr = s.Split ('.');
+			var vint = new int [vstr.Length];
+			for (int j = 0; j < vstr.Length; j++)
+				vint [j] = int.Parse (vstr [j]);
+			var rv = new T ();
+			rv.SetVersion (vint);
+			return rv;
+		}
+
+		public static bool Equals (IAppleSdkVersion a, IAppleSdkVersion b)
+		{
+			if ((object) a == (object) b)
+				return true;
+
+			if (a != null ^ b != null)
+				return false;
+
+			var x = a.Version;
+			var y = b.Version;
+			if (x == null || y == null || x.Length != y.Length)
+				return false;
+
+			for (int i = 0; i < x.Length; i++)
+				if (x [i] != y [i])
+					return false;
+
+			return true;
+		}
+
+		public static bool Equals (IAppleSdkVersion @this, object other)
+		{
+			if (other is IAppleSdkVersion obj)
+				return Equals (@this, obj);
+			return false;
+		}
+
+		public static int CompareTo (IAppleSdkVersion @this, IAppleSdkVersion other)
+		{
+			var x = @this.Version;
+			var y = other.Version;
+			if (ReferenceEquals (x, y))
+				return 0;
+
+			if (x == null)
+				return -1;
+			if (y == null)
+				return 1;
+
+			for (int i = 0; i < Math.Min (x.Length, y.Length); i++) {
+				int res = x [i] - y [i];
+				if (res != 0)
+					return res;
+			}
+			return x.Length - y.Length;
+		}
+
+		public static string ToString (IAppleSdkVersion @this)
+		{
+			if (@this.IsUseDefault)
+				return "";
+
+			var version = @this.Version;
+			var v = new string [version.Length];
+			for (int i = 0; i < v.Length; i++)
+				v [i] = version [i].ToString ();
+
+			return string.Join (".", v);
+		}
+
+		public static int GetHashCode (IAppleSdkVersion @this)
+		{
+			unchecked {
+				var x = @this.Version;
+				int acc = 0;
+				for (int i = 0; i < x.Length; i++)
+					acc ^= x [i] << i;
+				return acc;
+			}
 		}
 	}
 }

--- a/Xamarin.MacDev/IPhoneSdkVersion.cs
+++ b/Xamarin.MacDev/IPhoneSdkVersion.cs
@@ -29,6 +29,7 @@ using System;
 
 namespace Xamarin.MacDev
 {
+	[Obsolete ("Use 'AppleSdkVersion' instead.")]
 	public struct IPhoneSdkVersion : IComparable<IPhoneSdkVersion>, IEquatable<IPhoneSdkVersion>, IAppleSdkVersion
 	{
 		int[] version;
@@ -64,13 +65,7 @@ namespace Xamarin.MacDev
 
 		public static IPhoneSdkVersion Parse (string s)
 		{
-			var vstr = s.Split ('.');
-			var vint = new int[vstr.Length];
-
-			for (int j = 0; j < vstr.Length; j++)
-				vint[j] = int.Parse (vstr[j]);
-
-			return new IPhoneSdkVersion (vint);
+			return IAppleSdkVersion_Extensions.Parse<IPhoneSdkVersion> (s);
 		}
 		
 		public static bool TryParse (string s, out IPhoneSdkVersion result)
@@ -82,71 +77,32 @@ namespace Xamarin.MacDev
 		
 		public override string ToString ()
 		{
-			if (IsUseDefault)
-				return "";
-
-			var v = new string [version.Length];
-			for (int i = 0; i < v.Length; i++)
-				v[i] = version[i].ToString ();
-
-			return string.Join (".", v);
+			return IAppleSdkVersion_Extensions.ToString (this);
 		}
 		
 		public int CompareTo (IPhoneSdkVersion other)
 		{
-			var x = Version;
-			var y = other.Version;
-			if (ReferenceEquals (x, y))
-				return 0;
-			
-			if (x == null)
-				return -1;
-			if (y == null)
-				return 1;
-			
-			for (int i = 0; i < Math.Min (x.Length,y.Length); i++) {
-				int res = x[i] - y[i];
-				if (res != 0)
-					return res;
-			}
-			return x.Length - y.Length;
+			return IAppleSdkVersion_Extensions.CompareTo (this, other);
 		}
-		
+
+		public bool Equals (IAppleSdkVersion other)
+		{
+			return IAppleSdkVersion_Extensions.Equals (this, other);
+		}
+
 		public bool Equals (IPhoneSdkVersion other)
 		{
-			var x = Version;
-			var y = other.Version;
-			if (ReferenceEquals (x, y))
-				return true;
-			if (x == null || y == null || x.Length != y.Length)
-				return false;
-			for (int i = 0; i < x.Length; i++)
-				if (x[i] != y[i])
-					return false;
-			return true;
+			return IAppleSdkVersion_Extensions.Equals (this, other);
 		}
 		
 		public override bool Equals (object obj)
 		{
-			if (obj is IPhoneSdkVersion)
-				return Equals ((IPhoneSdkVersion)obj);
-			return false;
+			return IAppleSdkVersion_Extensions.Equals (this, obj);
 		}
 		
-		bool IEquatable<IAppleSdkVersion>.Equals (IAppleSdkVersion other)
-		{
-			return Equals ((object) other);
-		}
-
 		public override int GetHashCode ()
 		{
-			unchecked {
-				var x = Version;
-				int acc = 0;
-				for (int i = 0; i < x.Length; i++)
-					acc ^= x[i] << i;
-				return acc;
-			}
+			return IAppleSdkVersion_Extensions.GetHashCode (this);
 		}
 		
 		public static bool operator == (IPhoneSdkVersion a, IPhoneSdkVersion b)
@@ -189,15 +145,15 @@ namespace Xamarin.MacDev
 		}
 
 #if !WINDOWS
-		public IPhoneSdkVersion ResolveIfDefault (AppleSdk sdk, bool sim)
+		public IAppleSdkVersion ResolveIfDefault (AppleSdk sdk, bool sim)
 		{
 			return IsUseDefault ? GetDefault (sdk, sim) : this;
 		}
 
-		public static IPhoneSdkVersion GetDefault (AppleSdk sdk, bool sim)
+		public static IAppleSdkVersion GetDefault (AppleSdk sdk, bool sim)
 		{
 			var v = sdk.GetInstalledSdkVersions (sim);
-			return v.Count > 0 ? v[v.Count - 1] : UseDefault;
+			return v.Count > 0 ? v[v.Count - 1] : (IAppleSdkVersion) UseDefault;
 		}
 #endif
 

--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -32,15 +32,15 @@ namespace Xamarin.MacDev
 {
 	public class MacOSXSdk : IAppleSdk
 	{
-		List<MacOSXSdkVersion> knownOSVersions = new List<MacOSXSdkVersion> {
-			MacOSXSdkVersion.V10_7,
-			MacOSXSdkVersion.V10_8,
-			MacOSXSdkVersion.V10_9,
-			MacOSXSdkVersion.V10_10,
-			MacOSXSdkVersion.V10_11,
-			MacOSXSdkVersion.V10_12,
-			MacOSXSdkVersion.V10_13,
-            		MacOSXSdkVersion.V10_14
+		List<AppleSdkVersion> knownOSVersions = new List<AppleSdkVersion> {
+			AppleSdkVersion.V10_7,
+			AppleSdkVersion.V10_8,
+			AppleSdkVersion.V10_9,
+			AppleSdkVersion.V10_10,
+			AppleSdkVersion.V10_11,
+			AppleSdkVersion.V10_12,
+			AppleSdkVersion.V10_13,
+			AppleSdkVersion.V10_14,
         	};
 
 		static readonly Dictionary<string, AppleDTSdkSettings> sdkSettingsCache = new Dictionary<string, AppleDTSdkSettings> ();
@@ -82,19 +82,19 @@ namespace Xamarin.MacDev
 			if (IsInstalled) {
 				InstalledSdkVersions = EnumerateSdks (Path.Combine (SdkDeveloperRoot, "SDKs"), "MacOSX");
 			} else {
-				InstalledSdkVersions = new MacOSXSdkVersion[0];
+				InstalledSdkVersions = new AppleSdkVersion [0];
 			}
 		}
 
 		public bool IsInstalled { get; private set; }
-		public MacOSXSdkVersion[] InstalledSdkVersions { get; private set; }
+		public AppleSdkVersion [] InstalledSdkVersions { get; private set; }
 
-		public IList<MacOSXSdkVersion> KnownOSVersions { get { return knownOSVersions; } }
+		public IList<AppleSdkVersion> KnownOSVersions { get { return knownOSVersions; } }
 		
-		static MacOSXSdkVersion[] EnumerateSdks (string sdkDir, string name)
+		static AppleSdkVersion [] EnumerateSdks (string sdkDir, string name)
 		{
 			if (!Directory.Exists (sdkDir))
-				return new MacOSXSdkVersion[0];
+				return new AppleSdkVersion [0];
 			
 			var sdks = new List<string> ();
 			
@@ -114,10 +114,10 @@ namespace Xamarin.MacDev
 				sdks.Add (dirName);
 			}
 			
-			var vs = new List<MacOSXSdkVersion> ();
+			var vs = new List<AppleSdkVersion> ();
 			foreach (var s in sdks) {
 				try {
-					vs.Add (MacOSXSdkVersion.Parse (s));
+					vs.Add (AppleSdkVersion.Parse (s));
 				} catch (Exception ex) {
 					LoggingService.LogError ("Could not parse {0} SDK version '{1}':\n{2}", name, s, ex);
 				}
@@ -139,7 +139,7 @@ namespace Xamarin.MacDev
 			return GetPlatformPath ();
 		}
 		
-		public string GetSdkPath (MacOSXSdkVersion version)
+		public string GetSdkPath (AppleSdkVersion version)
 		{
 			return GetSdkPath (version.ToString ());
 		}
@@ -161,10 +161,10 @@ namespace Xamarin.MacDev
 
 		bool IAppleSdk.SdkIsInstalled (IAppleSdkVersion version, bool isSimulator)
 		{
-			return SdkIsInstalled ((MacOSXSdkVersion) version);
+			return SdkIsInstalled ((AppleSdkVersion) version);
 		}
 
-		public bool SdkIsInstalled (MacOSXSdkVersion version)
+		public bool SdkIsInstalled (AppleSdkVersion version)
 		{
 			foreach (var v in InstalledSdkVersions) {
 				if (v.Equals (version))
@@ -281,17 +281,17 @@ namespace Xamarin.MacDev
 			
 		IAppleSdkVersion IAppleSdk.GetClosestInstalledSdk (IAppleSdkVersion version, bool isSimulator)
 		{
-			return GetClosestInstalledSdk ((MacOSXSdkVersion) version);
+			return GetClosestInstalledSdk ((AppleSdkVersion) version);
 		}
 
-		public MacOSXSdkVersion GetClosestInstalledSdk (MacOSXSdkVersion v)
+		public AppleSdkVersion GetClosestInstalledSdk (AppleSdkVersion v)
 		{
 			// sorted low to high, so get first that's >= requested version
 			foreach (var i in GetInstalledSdkVersions ()) {
 				if (i.CompareTo (v) >= 0)
 					return i;
 			}
-			return MacOSXSdkVersion.UseDefault;
+			return AppleSdkVersion.UseDefault;
 		}
 		
 		IList<IAppleSdkVersion> IAppleSdk.GetInstalledSdkVersions (bool isSimulator)
@@ -299,14 +299,14 @@ namespace Xamarin.MacDev
 			return GetInstalledSdkVersions ().Cast<IAppleSdkVersion> ().ToArray ();
 		}
 
-		public IList<MacOSXSdkVersion> GetInstalledSdkVersions ()
+		public IList<AppleSdkVersion> GetInstalledSdkVersions ()
 		{
 			return InstalledSdkVersions;
 		}
 		
 		bool IAppleSdk.TryParseSdkVersion (string value, out IAppleSdkVersion version)
 		{
-			return IAppleSdkVersion_Extensions.TryParse<MacOSXSdkVersion> (value, out version);
+			return IAppleSdkVersion_Extensions.TryParse<AppleSdkVersion> (value, out version);
 		}
 
 		public class DTSettings

--- a/Xamarin.MacDev/MacOSXSdkVersion.cs
+++ b/Xamarin.MacDev/MacOSXSdkVersion.cs
@@ -27,6 +27,7 @@ using System;
 
 namespace Xamarin.MacDev
 {
+	[Obsolete ("Use 'AppleSdkVersion' instead.")]
 	public struct MacOSXSdkVersion : IComparable<MacOSXSdkVersion>, IEquatable<MacOSXSdkVersion>, IAppleSdkVersion
 	{
 		int[] version;
@@ -52,11 +53,7 @@ namespace Xamarin.MacDev
 
 		public static MacOSXSdkVersion Parse (string s)
 		{
-			var vstr = s.Split ('.');
-			var vint = new int[vstr.Length];
-			for (int j = 0; j < vstr.Length; j++)
-				vint[j] = int.Parse (vstr[j]);
-			return new MacOSXSdkVersion (vint);
+			return IAppleSdkVersion_Extensions.Parse<MacOSXSdkVersion> (s);
 		}
 		
 		public static bool TryParse (string s, out MacOSXSdkVersion result)
@@ -68,69 +65,32 @@ namespace Xamarin.MacDev
 		
 		public override string ToString ()
 		{
-			if (IsUseDefault)
-				return "";
-			var v = new string [version.Length];
-			for (int i = 0; i < v.Length; i++)
-				v[i] = version[i].ToString ();
-			return string.Join (".", v);
+			return IAppleSdkVersion_Extensions.ToString (this);
 		}
 		
 		public int CompareTo (MacOSXSdkVersion other)
 		{
-			var x = Version;
-			var y = other.Version;
-			if (ReferenceEquals (x, y))
-				return 0;
-			
-			if (x == null)
-				return -1;
-			if (y == null)
-				return 1;
-			
-			for (int i = 0; i < Math.Min (x.Length,y.Length); i++) {
-				int res = x[i] - y[i];
-				if (res != 0)
-					return res;
-			}
-			return x.Length - y.Length;
+			return IAppleSdkVersion_Extensions.CompareTo (this, other);
 		}
-		
+
 		public bool Equals (MacOSXSdkVersion other)
 		{
-			var x = Version;
-			var y = other.Version;
-			if (ReferenceEquals (x, y))
-				return true;
-			if (x == null || y == null || x.Length != y.Length)
-				return false;
-			for (int i = 0; i < x.Length; i++)
-				if (x[i] != y[i])
-					return false;
-			return true;
+			return IAppleSdkVersion_Extensions.Equals (this, other);
+		}
+
+		public bool Equals (IAppleSdkVersion other)
+		{
+			return IAppleSdkVersion_Extensions.Equals (this, other);
 		}
 		
 		public override bool Equals (object obj)
 		{
-			if (obj is MacOSXSdkVersion)
-				return Equals ((MacOSXSdkVersion)obj);
-			return false;
+			return IAppleSdkVersion_Extensions.Equals (this, obj);
 		}
 		
-		bool IEquatable<IAppleSdkVersion>.Equals (IAppleSdkVersion other)
-		{
-			return Equals ((object) other);
-		}
-
 		public override int GetHashCode ()
 		{
-			unchecked {
-				var x = Version;
-				int acc = 0;
-				for (int i = 0; i < x.Length; i++)
-					acc ^= x[i] << i;
-				return acc;
-			}
+			return IAppleSdkVersion_Extensions.GetHashCode (this);
 		}
 		
 		public static bool operator == (MacOSXSdkVersion a, MacOSXSdkVersion b)
@@ -174,18 +134,18 @@ namespace Xamarin.MacDev
 			return UseDefault;
 		}
 
-		public static MacOSXSdkVersion GetDefault (IAppleSdk sdk)
+		public static IAppleSdkVersion GetDefault (IAppleSdk sdk)
 		{
 			return GetDefault ((MacOSXSdk) sdk);
 		}
 
-		public static MacOSXSdkVersion GetDefault (MacOSXSdk sdk)
+		public static IAppleSdkVersion GetDefault (MacOSXSdk sdk)
 		{
 			var v = sdk.GetInstalledSdkVersions ();
-			return v.Count > 0 ? v [v.Count - 1] : UseDefault;
+			return v.Count > 0 ? v [v.Count - 1] : (IAppleSdkVersion) UseDefault;
 		}
 
-		public MacOSXSdkVersion ResolveIfDefault (MacOSXSdk sdk)
+		public IAppleSdkVersion ResolveIfDefault (MacOSXSdk sdk)
 		{
 			return IsUseDefault ? GetDefault (sdk) : this;
 		}

--- a/Xamarin.MacDev/MonoMacSdk.cs
+++ b/Xamarin.MacDev/MonoMacSdk.cs
@@ -65,27 +65,27 @@ namespace Xamarin.MacDev
 					LoggingService.LogInfo ("Found MonoMac, version {0}.", Version);
 			} else {
 				lastExeWrite = DateTime.MinValue;
-				Version = new MacOSXSdkVersion ();
+				Version = new AppleSdkVersion ();
 				LoggingService.LogInfo ("MonoMac not installed. Can't find {0}.", LegacyFrameworkAssembly);
 			}
 		}
 		
-		MacOSXSdkVersion ReadVersion ()
+		AppleSdkVersion ReadVersion ()
 		{
 			var versionFile = Path.Combine (SdkDir, "Version");
 			if (File.Exists (versionFile)) {
 				try {
-					return MacOSXSdkVersion.Parse (File.ReadAllText (versionFile).Trim ());
+					return AppleSdkVersion.Parse (File.ReadAllText (versionFile).Trim ());
 				} catch (Exception ex) {
 					LoggingService.LogError ("Failed to read MonoMac version", ex);
 				}
 			}
 			
-			return new MacOSXSdkVersion ();
+			return new AppleSdkVersion ();
 		}
 		
 		public bool IsInstalled { get; private set; }
-		public MacOSXSdkVersion Version { get; private set; }
+		public AppleSdkVersion Version { get; private set; }
 		
 		public void CheckCaches ()
 		{

--- a/Xamarin.MacDev/MonoTouchSdk.cs
+++ b/Xamarin.MacDev/MonoTouchSdk.cs
@@ -33,42 +33,42 @@ namespace Xamarin.MacDev
 {
 	public class MonoTouchSdk
 	{
-		static readonly IPhoneSdkVersion[] iOSSdkVersions = {
-			IPhoneSdkVersion.V6_0,
-			IPhoneSdkVersion.V6_1,
-			IPhoneSdkVersion.V7_0,
-			IPhoneSdkVersion.V7_1,
-			IPhoneSdkVersion.V8_0,
-			IPhoneSdkVersion.V8_1,
-			IPhoneSdkVersion.V8_2,
-			IPhoneSdkVersion.V8_3,
-			IPhoneSdkVersion.V8_4,
-			IPhoneSdkVersion.V9_0,
-			IPhoneSdkVersion.V9_1,
-			IPhoneSdkVersion.V9_2,
-			IPhoneSdkVersion.V9_3,
-			IPhoneSdkVersion.V10_0,
-			IPhoneSdkVersion.V10_1
+		static readonly AppleSdkVersion [] iOSSdkVersions = {
+			AppleSdkVersion.V6_0,
+			AppleSdkVersion.V6_1,
+			AppleSdkVersion.V7_0,
+			AppleSdkVersion.V7_1,
+			AppleSdkVersion.V8_0,
+			AppleSdkVersion.V8_1,
+			AppleSdkVersion.V8_2,
+			AppleSdkVersion.V8_3,
+			AppleSdkVersion.V8_4,
+			AppleSdkVersion.V9_0,
+			AppleSdkVersion.V9_1,
+			AppleSdkVersion.V9_2,
+			AppleSdkVersion.V9_3,
+			AppleSdkVersion.V10_0,
+			AppleSdkVersion.V10_1
 		};
-		static readonly IPhoneSdkVersion[] watchOSSdkVersions = {
-			IPhoneSdkVersion.V2_0,
-			IPhoneSdkVersion.V2_1,
-			IPhoneSdkVersion.V2_2,
-			IPhoneSdkVersion.V3_0,
-			IPhoneSdkVersion.V3_1
+		static readonly AppleSdkVersion [] watchOSSdkVersions = {
+			AppleSdkVersion.V2_0,
+			AppleSdkVersion.V2_1,
+			AppleSdkVersion.V2_2,
+			AppleSdkVersion.V3_0,
+			AppleSdkVersion.V3_1
 		};
-		static readonly IPhoneSdkVersion[] tvOSSdkVersions = {
-			IPhoneSdkVersion.V9_0,
-			IPhoneSdkVersion.V9_1,
-			IPhoneSdkVersion.V9_2,
-			IPhoneSdkVersion.V10_0
+		static readonly AppleSdkVersion [] tvOSSdkVersions = {
+			AppleSdkVersion.V9_0,
+			AppleSdkVersion.V9_1,
+			AppleSdkVersion.V9_2,
+			AppleSdkVersion.V10_0
 		};
 
 		public static readonly string[] DefaultLocations;
 
 		// Note: We require Xamarin.iOS 10.4 because it is the first version to bundle mlaunch. Prior to that Xamarin Studio would ship it but that is no longer the case.
 		// (We also need 10.4 for the Versions.plist, although we have a handy fallback if that file is missing)
-		static IPhoneSdkVersion requiredXI = IPhoneSdkVersion.V10_4;
+		static AppleSdkVersion requiredXI = AppleSdkVersion.V10_4;
 
 		DateTime lastMTExeWrite = DateTime.MinValue;
 		PDictionary versions;
@@ -110,7 +110,7 @@ namespace Xamarin.MacDev
 
 		public event EventHandler Changed;
 
-		static PArray CreateKnownSdkVersionsArray (IList<IPhoneSdkVersion> versions)
+		static PArray CreateKnownSdkVersionsArray (IList<AppleSdkVersion> versions)
 		{
 			var array = new PArray ();
 
@@ -219,7 +219,7 @@ namespace Xamarin.MacDev
 				} else {
 					SdkNotInstalledReason = string.Format ("Found unsupported Xamarin.iOS, version {0}.\nYou need Xamarin.iOS {1} or above.", Version, requiredXI.ToString ());
 					LoggingService.LogWarning (SdkNotInstalledReason);
-					Version = new IPhoneSdkVersion ();
+					Version = new AppleSdkVersion ();
 					versions = new PDictionary ();
 					IsInstalled = false;
 				}
@@ -227,7 +227,7 @@ namespace Xamarin.MacDev
 				AnalyticsService.ReportSdkVersion ("XS.Core.SDK.iOS.Version", Version.ToString ());
 			} else {
 				lastMTExeWrite = DateTime.MinValue;
-				Version = new IPhoneSdkVersion ();
+				Version = new AppleSdkVersion ();
 				versions = new PDictionary ();
 
 				SdkNotInstalledReason = string.Format ("Xamarin.iOS not installed.\nCan't find mtouch or the Version file at {0}.", SdkDir);
@@ -240,19 +240,19 @@ namespace Xamarin.MacDev
 				Changed (this, EventArgs.Empty);
 		}
 		
-		IPhoneSdkVersion ReadVersion ()
+		AppleSdkVersion ReadVersion ()
 		{
 			var versionFile = Path.Combine (SdkDir, "Version");
 
 			if (File.Exists (versionFile)) {
 				try {
-					return IPhoneSdkVersion.Parse (File.ReadAllText (versionFile).Trim ());
+					return AppleSdkVersion.Parse (File.ReadAllText (versionFile).Trim ());
 				} catch (Exception ex) {
 					LoggingService.LogError ("Failed to read Xamarin.iOS version", ex);
 				}
 			}
 
-			return new IPhoneSdkVersion ();
+			return new AppleSdkVersion ();
 		}
 
 		public static bool ValidateSdkLocation (string sdkDir)
@@ -289,7 +289,7 @@ namespace Xamarin.MacDev
 		}
 
 		public bool IsInstalled { get; private set; }
-		public IPhoneSdkVersion Version { get; private set; }
+		public AppleSdkVersion Version { get; private set; }
 
 		ExtendedVersion extended_version;
 		public ExtendedVersion ExtendedVersion {
@@ -327,9 +327,9 @@ namespace Xamarin.MacDev
 			}
 		}
 
-		public IList<IPhoneSdkVersion> GetKnownSdkVersions (PlatformName platform)
+		public IList<AppleSdkVersion> GetKnownSdkVersions (PlatformName platform)
 		{
-			var list = new List<IPhoneSdkVersion> ();
+			var list = new List<AppleSdkVersion> ();
 			var key = GetPlatformKey (platform);
 			PDictionary knownVersions;
 
@@ -338,9 +338,7 @@ namespace Xamarin.MacDev
 
 				if (knownVersions.TryGetValue (key, out array)) {
 					foreach (var knownVersion in array.OfType<PString> ()) {
-						IPhoneSdkVersion version;
-
-						if (IPhoneSdkVersion.TryParse (knownVersion.Value, out version))
+						if (AppleSdkVersion.TryParse (knownVersion.Value, out var version))
 							list.Add (version);
 					}
 				}
@@ -349,7 +347,7 @@ namespace Xamarin.MacDev
 			return list;
 		}
 
-		public IPhoneSdkVersion GetMinimumExtensionVersion (PlatformName platform, string extension)
+		public AppleSdkVersion GetMinimumExtensionVersion (PlatformName platform, string extension)
 		{
 			var key = GetPlatformKey (platform);
 			PDictionary minExtensionVersions;
@@ -361,15 +359,13 @@ namespace Xamarin.MacDev
 					PString value;
 
 					if (extensions.TryGetValue (extension, out value)) {
-						IPhoneSdkVersion version;
-
-						if (IPhoneSdkVersion.TryParse (value.Value, out version))
+						if (AppleSdkVersion.TryParse (value.Value, out var version))
 							return version;
 					}
 				}
 			}
 
-			return IPhoneSdkVersion.V8_0;
+			return AppleSdkVersion.V8_0;
 		}
 		
 		public void CheckCaches ()

--- a/Xamarin.MacDev/XamMacSdk.cs
+++ b/Xamarin.MacDev/XamMacSdk.cs
@@ -16,13 +16,13 @@ namespace Xamarin.MacDev
 {
 	public sealed class XamMacSdk : IMonoMacSdk
 	{
-		static readonly MacOSXSdkVersion[] MacOSXSdkVersions = {
-			MacOSXSdkVersion.V10_7,
-			MacOSXSdkVersion.V10_8,
-			MacOSXSdkVersion.V10_9,
-			MacOSXSdkVersion.V10_10,
-			MacOSXSdkVersion.V10_11,
-			MacOSXSdkVersion.V10_12
+		static readonly AppleSdkVersion [] MacOSXSdkVersions = {
+			AppleSdkVersion.V10_7,
+			AppleSdkVersion.V10_8,
+			AppleSdkVersion.V10_9,
+			AppleSdkVersion.V10_10,
+			AppleSdkVersion.V10_11,
+			AppleSdkVersion.V10_12
 		};
 
 		readonly Dictionary<string, DateTime> lastWriteTimes = new Dictionary<string, DateTime> ();
@@ -32,7 +32,7 @@ namespace Xamarin.MacDev
 
 		public bool IsInstalled { get; private set; }
 
-		public MacOSXSdkVersion Version { get; private set; }
+		public AppleSdkVersion Version { get; private set; }
 		public string SdkNotInstalledReason { get; private set; }
 
 		public string FrameworkDirectory { get; private set; }
@@ -55,7 +55,7 @@ namespace Xamarin.MacDev
 
 		public event EventHandler Changed;
 
-		static PArray CreateKnownSdkVersionsArray (IList<MacOSXSdkVersion> versions)
+		static PArray CreateKnownSdkVersionsArray (IList<AppleSdkVersion> versions)
 		{
 			var array = new PArray ();
 
@@ -89,23 +89,23 @@ namespace Xamarin.MacDev
 			return minExtensionVersions;
 		}
 
-		static PArray CreateDefaultFeatures (MacOSXSdkVersion version)
+		static PArray CreateDefaultFeatures (AppleSdkVersion version)
 		{
 			var features = new PArray ();
 
-			if (version >= new MacOSXSdkVersion (1, 9, 0))
+			if (version >= new AppleSdkVersion (1, 9, 0))
 				features.Add (new PString ("activation"));
-			if (version >= new MacOSXSdkVersion (1, 11, 0) && version < new MacOSXSdkVersion (2, 5, 0))
+			if (version >= new AppleSdkVersion (1, 11, 0) && version < new AppleSdkVersion (2, 5, 0))
 				features.Add (new PString ("ref-counting"));
-			if (version >= new MacOSXSdkVersion (2, 5, 0))
+			if (version >= new AppleSdkVersion (2, 5, 0))
 				features.Add (new PString ("modern-http-client"));
-			if (version >= new MacOSXSdkVersion (2, 10, 0))
+			if (version >= new AppleSdkVersion (2, 10, 0))
 				features.Add (new PString ("mono-symbol-archive"));
 
 			return features;
 		}
 
-		static PDictionary CreateDefaultVersionsPlist (MacOSXSdkVersion version)
+		static PDictionary CreateDefaultVersionsPlist (AppleSdkVersion version)
 		{
 			var versions = new PDictionary ();
 
@@ -151,7 +151,7 @@ namespace Xamarin.MacDev
 				return;
 			}
 
-			var paths = Version >= new MacOSXSdkVersion (1, 9, 0)
+			var paths = Version >= new AppleSdkVersion (1, 9, 0)
 				? Detect2x ()
 				: Detect1x ();
 
@@ -182,7 +182,7 @@ namespace Xamarin.MacDev
 
 			SupportsFullProfile =
 				File.Exists (UnifiedFullProfileFrameworkAssembly) &&
-				Version >= new MacOSXSdkVersion (1, 11, 2, 3);
+				Version >= new AppleSdkVersion (1, 11, 2, 3);
 		}
 
 		IEnumerable<string> Detect1x ()
@@ -191,10 +191,10 @@ namespace Xamarin.MacDev
 			var appDriverPath = monoMacAppLauncherPath;
 
 			// 1.2.13 began bundling its own launcher
-			if (Version >= new MacOSXSdkVersion (1, 2, 13))
+			if (Version >= new AppleSdkVersion (1, 2, 13))
 				appDriverPath = Path.Combine (FrameworkDirectory, "lib", "mono", "XamMacLauncher");
 
-			if (Version < new MacOSXSdkVersion (1, 4, 0))
+			if (Version < new AppleSdkVersion (1, 4, 0))
 				usrPrefix = "usr";
 
 			yield return MmpPath = Path.Combine (FrameworkDirectory, usrPrefix, "bin", "mmp");
@@ -213,7 +213,7 @@ namespace Xamarin.MacDev
 			versions = new PDictionary ();
 			lastWriteTimes.Clear ();
 			IsInstalled = false;
-			Version = new MacOSXSdkVersion ();
+			Version = new AppleSdkVersion ();
 
 			SdkNotInstalledReason = string.Format ("Xamarin.Mac not installed. Can't find {0}.", pathMissing);
 
@@ -223,13 +223,13 @@ namespace Xamarin.MacDev
 				LoggingService.LogInfo (SdkNotInstalledReason);
 		}
 
-		MacOSXSdkVersion ReadVersion (string versionPath)
+		AppleSdkVersion ReadVersion (string versionPath)
 		{
 			try {
-				return MacOSXSdkVersion.Parse (File.ReadAllText (versionPath).Trim ());
+				return AppleSdkVersion.Parse (File.ReadAllText (versionPath).Trim ());
 			} catch (Exception ex) {
 				LoggingService.LogError ("Failed to read Xamarin.Mac version", ex);
-				return new MacOSXSdkVersion ();
+				return new AppleSdkVersion ();
 			}
 		}
 
@@ -265,15 +265,15 @@ namespace Xamarin.MacDev
 		}
 
 		public bool SupportsMSBuild {
-			get { return Version >= new MacOSXSdkVersion (1, 9, 0); }
+			get { return Version >= new AppleSdkVersion (1, 9, 0); }
 		}
 
 		public bool SupportsV2Features {
-			get { return Version >= new MacOSXSdkVersion (1, 9, 0); }
+			get { return Version >= new AppleSdkVersion (1, 9, 0); }
 		}
 
 		public bool SupportsNewStyleActivation {
-			get { return Version >= new MacOSXSdkVersion (1, 9, 0); }
+			get { return Version >= new AppleSdkVersion (1, 9, 0); }
 		}
 
 		public bool SupportsFullProfile { get; private set; }


### PR DESCRIPTION
This reduces code duplication and makes it possible to simplify logic in a few places.