### PR TITLE
Adding MacCatalyst option to GetPlatformKey()

### DIFF
--- a/Xamarin.MacDev/MonoTouchSdk.cs
+++ b/Xamarin.MacDev/MonoTouchSdk.cs
@@ -311,6 +311,7 @@ namespace Xamarin.MacDev
 			case PlatformName.iOS: return "iOS";
 			case PlatformName.WatchOS: return "watchOS";
 			case PlatformName.TvOS: return "tvOS";
+			case PlatformName.MacOSX: return "MacCatalyst";
 			default: throw new ArgumentOutOfRangeException (nameof (platform));
 			}
 		}


### PR DESCRIPTION
### Description
As part of the work to support the Info.plist editor on MAUI projects, we need to add the `MacCatalyst` option to this method `GetPlatformKey()`. This method is used to get the key for loading the known SDK versions for the manifest editor as shown in the image below.  

<img width="567" alt="Screen Shot 2022-08-02 at 9 49 53 AM" src="https://user-images.githubusercontent.com/77985069/182430417-0e82bbc0-36fd-4ed2-b38f-68fcc11aec4d.png">
