### PR TITLE
Adding support for MacCatalyst versions

### DIFF
--- a/Xamarin.MacDev/MonoTouchSdk.cs
+++ b/Xamarin.MacDev/MonoTouchSdk.cs
@@ -338,9 +338,22 @@ namespace Xamarin.MacDev
 				PArray array;
 
 				if (knownVersions.TryGetValue (key, out array)) {
-					foreach (var knownVersion in array.OfType<PString> ()) {
-						if (AppleSdkVersion.TryParse (knownVersion.Value, out var version))
-							list.Add (version);
+					versions.TryGetValue("MacCatalystVersionMap", out PDictionary macCatalystVersionMap);
+
+					foreach (var knownVersion in array.OfType<PString>())
+					{
+						string versionValue = knownVersion.Value;
+
+						// For MacCatalyst we need to convert the versions to supported versions using the map
+						if (platform == PlatformName.MacOSX) {
+							if (macCatalystVersionMap != null) {
+								if (macCatalystVersionMap.TryGetValue(knownVersion, out PString value))
+									versionValue = value.Value;
+							}
+						}
+
+						if (AppleSdkVersion.TryParse(versionValue, out var version))
+							list.Add(version);
 					}
 				}
 			}


### PR DESCRIPTION
### Description 
This change converts the MacCatalyst known versions to the actual supported versions using the provided map in the `/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/Versions.plist` file.

<img width="680" alt="Screen Shot 2022-08-02 at 2 38 26 PM" src="https://user-images.githubusercontent.com/77985069/182479436-27346b88-3617-4e90-8c68-65a4ad217f73.png">
