### PR TITLE
Only build Xamarin.MacDev for net461 on Windows due to strongnamer issue

### DIFF
--- a/Xamarin.MacDev/Xamarin.MacDev.csproj
+++ b/Xamarin.MacDev/Xamarin.MacDev.csproj
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <!--We only build for net461 on Windows due to open issue with strong namer package: https://github.com/dsplaisted/strongnamer/issues/58-->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Problem
There is an issue when building the project Xamarin.MacDev from XamarinVS in the IDE (as a submodule):
![image](https://user-images.githubusercontent.com/59936622/197078319-7e9af6c5-f65c-4c08-acd2-2acbccd95594.png)

This is a known issue with the strongnamer package:

[Add support for multiple frameworks at same time · Issue #58 · dsplaisted/strongnamer (github.com)](https://github.com/dsplaisted/strongnamer/issues/58)

## Solution
The solution as suggested by @rolfbjarne and @mauroa is to only build XamarinMacDev for net461 on Windows. It is still necessary to build for netstandard2.0 on Mac.

![image](https://user-images.githubusercontent.com/59936622/197078516-dc2c2f21-8b31-4d85-8e3a-0a16cc4608f2.png)
