### PR TITLE
Add Extended Version info to XamMac

### DIFF
--- a/Xamarin.MacDev/ExtendedVersion.cs
+++ b/Xamarin.MacDev/ExtendedVersion.cs
@@ -33,7 +33,7 @@ namespace Xamarin.MacDev {
 				case "Branch":
 					rv.Branch = value;
 					break;
-				case "BuildDate":
+				case "Build date":
 					rv.BuildDate = value;
 					break;
 				}

--- a/Xamarin.MacDev/XamMacSdk.cs
+++ b/Xamarin.MacDev/XamMacSdk.cs
@@ -27,6 +27,7 @@ namespace Xamarin.MacDev {
 
 		string monoMacAppLauncherPath;
 		PDictionary versions;
+		ExtendedVersion extended_version;
 
 		public bool IsInstalled { get; private set; }
 
@@ -302,6 +303,18 @@ namespace Xamarin.MacDev {
 
 		public bool SupportsSiriIntents {
 			get { return CheckSupportsFeature ("siri-intents"); }
+		}
+
+		public ExtendedVersion ExtendedVersion
+		{
+			get
+			{
+				if (extended_version == null)
+				{
+					extended_version = ExtendedVersion.Read(Path.Combine(FrameworkDirectory, "buildinfo"));
+				}
+				return extended_version;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Having an easy way to access the SDK's is convenient since this information is retrieved by the IDE in the "About VS Mac" section. Rather than having to re-write the parsing code, I prefer on reusing what we already have

These changes simply make use of the already existing code used in MonoTouchSDK: 
https://github.com/xamarin/Xamarin.MacDev/blob/main/Xamarin.MacDev/MonoTouchSdk.cs#L292-L304

I also corrected the fact that we were not parsing for the "Build date" property correctly