### PR TITLE
Use Environment.SpecialFolder.UserProfile, not SpecialFolder.Personal.

### DIFF
--- a/Xamarin.MacDev/AppleSdkSettings.cs
+++ b/Xamarin.MacDev/AppleSdkSettings.cs
@@ -140,7 +140,7 @@ namespace Xamarin.MacDev {
 
 		static AppleSdkSettings ()
 		{
-			var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+			var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 			var preferences = Path.Combine (home, "Library", "Preferences", "Xamarin");
 
 			if (!Directory.Exists (preferences))

--- a/Xamarin.MacDev/MobileProvision.cs
+++ b/Xamarin.MacDev/MobileProvision.cs
@@ -56,7 +56,7 @@ namespace Xamarin.MacDev {
 		{
 			if (Environment.OSVersion.Platform == PlatformID.MacOSX
 				|| Environment.OSVersion.Platform == PlatformID.Unix) {
-				string personal = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				string personal = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 				ProfileDirectory = Path.Combine (personal, "Library", "MobileDevice", "Provisioning Profiles");
 			} else {
 				ProfileDirectory = Path.Combine (

--- a/Xamarin.MacDev/MobileProvisionIndex.cs
+++ b/Xamarin.MacDev/MobileProvisionIndex.cs
@@ -193,7 +193,7 @@ namespace Xamarin.MacDev {
 			string xamarinFolder;
 
 			if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
-				xamarinFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "Library", "Xamarin");
+				xamarinFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Xamarin");
 			} else {
 				xamarinFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "iOS", "Provisioning");
 			}


### PR DESCRIPTION
Context: dotnet/runtime#68610
Context: https://github.com/xamarin/xamarin-android-tools/commit/0be567a9

In Mono and .NET prior to .NET 8, the
[`System.Environment.SpecialFolder`][0]`.Personal` enum value would refer to
`$HOME` on Unix platforms.

This will be changing in .NET 8, such that
`Environment.SpecialFolder.Personal` will instead refer to
`$XDG_DOCUMENTS_DIR` (if set) or `$HOME/Documents`.  This is for "semantic
compatibility" with .NET on Windows.

Replace usage of `Environment.SpecialFolder.Personal` with
`Environment.SpecialFolder.UserProfile`, so that our code continues to work as
expected under .NET 8.

[0]: https://docs.microsoft.com/en-us/dotnet/api/system.environment.specialfolder?view=net-6.0