### PR TITLE
Fix build by always including the System.Diagnostics.CodeAnalysis namespace.

### DIFF
--- a/Xamarin.MacDev/MacCatalystSupport.cs
+++ b/Xamarin.MacDev/MacCatalystSupport.cs
@@ -26,9 +26,7 @@
 #nullable enable
 
 using System;
-#if NET
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Collections.Generic;
 using System.IO;
 


### PR DESCRIPTION
This way we find the NotNullWhen attribute declared at the bottom of this file.