### PR TITLE
[Xamarin.MacDev] Always fetch the DTSDKBuild variable.

### DIFF
--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -144,11 +144,9 @@ namespace Xamarin.MacDev {
 				settings.DTCompiler = gcc.Value;
 
 			settings.DeviceFamilies = props.GetUIDeviceFamily ("SUPPORTED_DEVICE_FAMILIES");
-			if (!isSim) {
-				var plstPlist = Path.Combine (GetPlatformPath (isSim), PLATFORM_VERSION_PLIST);
-				settings.DTSDKBuild = GrabRootString (plstPlist, "ProductBuildVersion");
-			}
-
+			var plstPlist = Path.Combine (GetPlatformPath (isSim), PLATFORM_VERSION_PLIST);
+			settings.DTSDKBuild = GrabRootString (plstPlist, "ProductBuildVersion");
+			
 			return settings;
 		}
 

--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -146,7 +146,7 @@ namespace Xamarin.MacDev {
 			settings.DeviceFamilies = props.GetUIDeviceFamily ("SUPPORTED_DEVICE_FAMILIES");
 			var plstPlist = Path.Combine (GetPlatformPath (isSim), PLATFORM_VERSION_PLIST);
 			settings.DTSDKBuild = GrabRootString (plstPlist, "ProductBuildVersion");
-			
+
 			return settings;
 		}
 


### PR DESCRIPTION
Xcode adds this value to the Info.plist for all builds, so we should also get it
always so that our build can do the same as Xcode.