### PR TITLE
[Xamarin.MacDev] Move compatibility nullability attributes to their own file.

### DIFF
--- a/Xamarin.MacDev/MacCatalystSupport.cs
+++ b/Xamarin.MacDev/MacCatalystSupport.cs
@@ -103,14 +103,3 @@ namespace Xamarin.MacDev {
 		}
 	}
 }
-
-#if !NET
-namespace System.Diagnostics.CodeAnalysis {
-	// from: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
-	[AttributeUsage (AttributeTargets.Parameter, Inherited = false)]
-	internal sealed class NotNullWhenAttribute : Attribute {
-		public NotNullWhenAttribute (bool returnValue) => ReturnValue = returnValue;
-		public bool ReturnValue { get; }
-	}
-}
-#endif // !NET

--- a/Xamarin.MacDev/NullableAttributes.cs
+++ b/Xamarin.MacDev/NullableAttributes.cs
@@ -1,0 +1,39 @@
+//
+// NullableAttributes.cs
+//
+// Author: Rolf Kvinge <rolf@xamarin.com>
+//
+// Copyright (c) 2023 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#nullable enable
+
+using System;
+
+#if !NET
+namespace System.Diagnostics.CodeAnalysis {
+	// from: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+	[AttributeUsage (AttributeTargets.Parameter, Inherited = false)]
+	internal sealed class NotNullWhenAttribute : Attribute {
+		public NotNullWhenAttribute (bool returnValue) => ReturnValue = returnValue;
+		public bool ReturnValue { get; }
+	}
+}
+#endif // !NET


### PR DESCRIPTION
This makes it possible for other projects to just include the MacCatalystSupport.cs file without getting the nullability attributes as well.