### PR TITLE
[Xamarin.MacDev] Fix computing DTSDKBuild. Fixes #xamarin/xamarin-macios@19733.

### DIFF
--- a/Xamarin.MacDev/AppleSdk.cs
+++ b/Xamarin.MacDev/AppleSdk.cs
@@ -172,13 +172,12 @@ namespace Xamarin.MacDev {
 
 			var dict = PDictionary.FromFile (Path.Combine (DevicePlatform, "Info.plist"));
 			var infos = dict.Get<PDictionary> ("AdditionalInfo");
-			var systemVersionPlist = Path.Combine (DeveloperRoot, SYSTEM_VERSION_PLIST);
 
 			return (dtSettings = new AppleDTSettings {
 				DTPlatformVersion = infos.Get<PString> ("DTPlatformVersion").Value,
 				DTPlatformBuild = GrabRootString (Path.Combine (DevicePlatform, "version.plist"), "ProductBuildVersion"),
 				DTXcodeBuild = GrabRootString (VersionPlist, "ProductBuildVersion"),
-				BuildMachineOSBuild = GrabRootString (systemVersionPlist, "ProductBuildVersion"),
+				BuildMachineOSBuild = GrabRootString (SYSTEM_VERSION_PLIST, "ProductBuildVersion"),
 			});
 		}
 

--- a/Xamarin.MacDev/MacOSXSdk.cs
+++ b/Xamarin.MacDev/MacOSXSdk.cs
@@ -260,7 +260,10 @@ namespace Xamarin.MacDev {
 			else
 				settings.DTCompiler = gcc.Value;
 
-			settings.DTSDKBuild = GrabRootString (Path.Combine (DeveloperRoot, SYSTEM_VERSION_PLIST), "ProductBuildVersion");
+			var sdkPath = GetSdkPath (sdk.ToString ());
+			// Do not do 'Path.Combine (sdkPath, SYSTEM_VERSION_PLIST)', because SYSTEM_VERSION_PLIST starts with a slash,
+			// and thus Path.Combine wouldn't combine, just return SYSTEM_VERSION_PLIST.
+			settings.DTSDKBuild = GrabRootString (sdkPath + SYSTEM_VERSION_PLIST, "ProductBuildVersion");
 
 			return settings;
 		}
@@ -278,13 +281,12 @@ namespace Xamarin.MacDev {
 
 			var dict = PDictionary.FromFile (Path.Combine (DesktopPlatform, "Info.plist"));
 			var infos = dict.Get<PDictionary> ("AdditionalInfo");
-			var systemVersionPlist = Path.Combine (DeveloperRoot, SYSTEM_VERSION_PLIST);
 
 			return (dtSettings = new DTSettings {
 				DTPlatformVersion = infos.Get<PString> ("DTPlatformVersion").Value,
 				DTPlatformBuild = GrabRootString (Path.Combine (DesktopPlatform, "version.plist"), "ProductBuildVersion") ?? GrabRootString (VersionPlist, "ProductBuildVersion"),
 				DTXcodeBuild = GrabRootString (VersionPlist, "ProductBuildVersion"),
-				BuildMachineOSBuild = GrabRootString (systemVersionPlist, "ProductBuildVersion"),
+				BuildMachineOSBuild = GrabRootString (SYSTEM_VERSION_PLIST, "ProductBuildVersion"),
 			});
 		}
 


### PR DESCRIPTION
We were accidentally getting the ProductBuildVersion value (which is used for
DTSDKBuild) from the system, not from the SDK used during the build.

This happened because we were trying to Path.Combine two rooted paths - in
which case Path.Combine returns the second path, without combining anything.

The fix is to compute the path of the plist where the ProductBuildVersion
value is located correctly.

Fixing the Path.Combine issue also revealed that the first path passed to
Path.Combine was wrong, so that got fixed too.

And finally make sure we don't Path.Combine two rooted paths anywhere else -
in all other cases we're supposed to just use the second path without
prepending the first, so just remove the Path.Combine call completely in those
cases.

Fixes https://github.com/xamarin/xamarin-macios/issues/19733.