### PR TITLE
Stop targeting net472

### DIFF
--- a/Xamarin.MacDev/Xamarin.MacDev.csproj
+++ b/Xamarin.MacDev/Xamarin.MacDev.csproj
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!--We only build for net4x on Windows due to open issue with strong namer package: https://github.com/dsplaisted/strongnamer/issues/58-->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;net472</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
As the Pair to Mac agents in VS are being migrated to target .NET 8, we no longer need to target .NET Framework 4.7.2.