### PR TITLE
Add support for symbolic links for provisioning profiles folder

### DIFF
--- a/Xamarin.MacDev/MobileProvisionIndex.cs
+++ b/Xamarin.MacDev/MobileProvisionIndex.cs
@@ -267,18 +267,18 @@ namespace Xamarin.MacDev {
 		/// Determines the last write time in UTC for the specified directory path or the target directory if the path is a symbolic link.
 		/// Returns the latest date of both.
 		/// </summary>
-		static DateTime GetLastWriteTimeUtcForPath(string path)
+		static DateTime GetLastWriteTimeUtcForPath (string path)
 		{
-			var lastWriteTimeUtcForPath = Directory.GetLastWriteTimeUtc(path);
-			
+			var lastWriteTimeUtcForPath = Directory.GetLastWriteTimeUtc (path);
+
 			// check symbolic link
-			var dirInfo = new DirectoryInfo(path);
-			if ( dirInfo.LinkTarget != null) {
-				var lastWriteTimeUtcforLink = Directory.GetLastWriteTimeUtc(dirInfo.LinkTarget);
-				return new DateTime(Math.Max(lastWriteTimeUtcForPath.Ticks, lastWriteTimeUtcforLink.Ticks));
+			var dirInfo = new DirectoryInfo (path);
+			if (dirInfo.LinkTarget is not null) {
+				var lastWriteTimeUtcforLink = Directory.GetLastWriteTimeUtc (dirInfo.LinkTarget);
+				return new DateTime (Math.Max (lastWriteTimeUtcForPath.Ticks, lastWriteTimeUtcforLink.Ticks));
 			}
 
-			return lastWriteTimeUtcForPath; 
+			return lastWriteTimeUtcForPath;
 		}
 
 		public static MobileProvisionIndex CreateIndex (string profilesDir, string indexName)


### PR DESCRIPTION
If the provisioning profile folder is a symbolic link, the index file "Provisioning Profiles.index" is never recreated. 

Adding or changing provisioning profiles has no effect on the last write time of the folder. Only the last write time of the target is changed.