### PR TITLE
Updated to use Xcode 16's new provisioning profiles directory

### DIFF
--- a/UnitTests/TestHelper.cs
+++ b/UnitTests/TestHelper.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // TestHelper.cs
 //
 // Author: Jeffrey Stedfast <jestedfa@microsoft.com>
@@ -30,8 +30,7 @@ using NUnit.Framework;
 
 namespace UnitTests {
 	[SetUpFixture]
-	static class TestHelper
-	{
+	static class TestHelper {
 		public static readonly string ProjectDir;
 
 		static TestHelper ()
@@ -44,7 +43,7 @@ namespace UnitTests {
 				codeBase = codeBase.Substring ("file://".Length);
 
 			if (Path.DirectorySeparatorChar == '\\') {
-				if (codeBase[0] == '/')
+				if (codeBase [0] == '/')
 					codeBase = codeBase.Substring (1);
 
 				codeBase = codeBase.Replace ('/', '\\');

--- a/UnitTests/TestHelper.cs
+++ b/UnitTests/TestHelper.cs
@@ -1,0 +1,62 @@
+﻿//
+// TestHelper.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+namespace UnitTests {
+	[SetUpFixture]
+	static class TestHelper
+	{
+		public static readonly string ProjectDir;
+
+		static TestHelper ()
+		{
+#if NET5_0_OR_GREATER
+			var codeBase = typeof (TestHelper).Assembly.Location;
+#else
+			var codeBase = typeof (TestHelper).Assembly.CodeBase;
+			if (codeBase.StartsWith ("file://", StringComparison.OrdinalIgnoreCase))
+				codeBase = codeBase.Substring ("file://".Length);
+
+			if (Path.DirectorySeparatorChar == '\\') {
+				if (codeBase[0] == '/')
+					codeBase = codeBase.Substring (1);
+
+				codeBase = codeBase.Replace ('/', '\\');
+			}
+#endif
+
+			var dir = Path.GetDirectoryName (codeBase);
+
+			while (Path.GetFileName (dir) != "UnitTests")
+				dir = Path.GetFullPath (Path.Combine (dir, ".."));
+
+			ProjectDir = Path.GetFullPath (dir);
+		}
+	}
+}

--- a/UnitTests/TestMobileProvisionIndex.cs
+++ b/UnitTests/TestMobileProvisionIndex.cs
@@ -33,7 +33,14 @@ using Xamarin.MacDev;
 namespace UnitTests {
 	[TestFixture]
 	public class TestMobileProvisionIndex {
-		static readonly string[] ProfileDirectories = new string [] { "../../TestData/Provisioning Profiles" };
+		static readonly string[] ProfileDirectories;
+
+		static TestMobileProvisionIndex ()
+		{
+			ProfileDirectories = new string [] {
+				Path.Combine (TestHelper.ProjectDir, "TestData", "Provisioning Profiles")
+			};
+		}
 
 		[Test]
 		public void TestCreateIndex ()

--- a/UnitTests/TestMobileProvisionIndex.cs
+++ b/UnitTests/TestMobileProvisionIndex.cs
@@ -33,7 +33,7 @@ using Xamarin.MacDev;
 namespace UnitTests {
 	[TestFixture]
 	public class TestMobileProvisionIndex {
-		static readonly string[] ProfileDirectories;
+		static readonly string [] ProfileDirectories;
 
 		static TestMobileProvisionIndex ()
 		{

--- a/UnitTests/TestMobileProvisionIndex.cs
+++ b/UnitTests/TestMobileProvisionIndex.cs
@@ -33,10 +33,12 @@ using Xamarin.MacDev;
 namespace UnitTests {
 	[TestFixture]
 	public class TestMobileProvisionIndex {
+		static readonly string[] ProfileDirectories = new string [] { "../../TestData/Provisioning Profiles" };
+
 		[Test]
 		public void TestCreateIndex ()
 		{
-			var index = MobileProvisionIndex.CreateIndex ("../../TestData/Provisioning Profiles", "profiles.index");
+			var index = MobileProvisionIndex.CreateIndex (ProfileDirectories, "profiles.index");
 
 			Assert.AreEqual (2, index.ProvisioningProfiles.Count);
 
@@ -77,7 +79,7 @@ namespace UnitTests {
 		[Test]
 		public void TestOpenIndex ()
 		{
-			var index = MobileProvisionIndex.OpenIndex ("../../TestData/Provisioning Profiles", "profiles.index");
+			var index = MobileProvisionIndex.OpenIndex (ProfileDirectories, "profiles.index");
 
 			Assert.AreEqual (2, index.ProvisioningProfiles.Count);
 

--- a/Xamarin.MacDev/MobileProvision.cs
+++ b/Xamarin.MacDev/MobileProvision.cs
@@ -50,7 +50,7 @@ namespace Xamarin.MacDev {
 		public const string AutomaticAppStore = "Automatic:AppStore";
 		public const string AutomaticInHouse = "Automatic:InHouse";
 		public const string AutomaticAdHoc = "Automatic:AdHoc";
-		public static readonly string[] ProfileDirectories;
+		public static readonly string [] ProfileDirectories;
 
 		static MobileProvision ()
 		{
@@ -58,7 +58,7 @@ namespace Xamarin.MacDev {
 				|| Environment.OSVersion.Platform == PlatformID.Unix) {
 				string personal = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 
-				ProfileDirectories = new string[] {
+				ProfileDirectories = new string [] {
 					// Xcode >= 16.x uses ~/Library/Developer/Xcode/UserData/Provisioning Profiles
 					Path.Combine (personal, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles"),
 

--- a/Xamarin.MacDev/MobileProvision.cs
+++ b/Xamarin.MacDev/MobileProvision.cs
@@ -50,7 +50,7 @@ namespace Xamarin.MacDev {
 		public const string AutomaticAppStore = "Automatic:AppStore";
 		public const string AutomaticInHouse = "Automatic:InHouse";
 		public const string AutomaticAdHoc = "Automatic:AdHoc";
-		public static readonly string ProfileDirectory;
+		public static readonly string[] ProfileDirectories;
 
 		static MobileProvision ()
 		{
@@ -58,22 +58,19 @@ namespace Xamarin.MacDev {
 				|| Environment.OSVersion.Platform == PlatformID.Unix) {
 				string personal = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 
-				// Xcode >= 16.x uses ~/Library/Developer/Xcode/UserData/Provisioning Profiles
-				string profileDir = Path.Combine (personal, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles");
+				ProfileDirectories = new string[] {
+					// Xcode >= 16.x uses ~/Library/Developer/Xcode/UserData/Provisioning Profiles
+					Path.Combine (personal, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles"),
 
-				if (!Directory.Exists (profileDir)) {
 					// Xcode < 16.x uses ~/Library/MobileDevice/Provisioning Profiles
-					profileDir = Path.Combine (personal, "Library", "MobileDevice", "Provisioning Profiles");
-				}
-
-				ProfileDirectory = profileDir;
+					Path.Combine (personal, "Library", "MobileDevice", "Provisioning Profiles"),
+				};
 			} else {
-				ProfileDirectory = Path.Combine (
-					Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData),
-					"Xamarin",
-					"iOS",
-					"Provisioning",
-					"Profiles");
+				var appDataLocal = Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData);
+
+				ProfileDirectories = new string [] {
+					Path.Combine (appDataLocal, "Xamarin", "iOS", "Provisioning", "Profiles")
+				};
 			}
 		}
 
@@ -154,9 +151,6 @@ namespace Xamarin.MacDev {
 		/// </summary>
 		public static IList<MobileProvision> GetAllInstalledProvisions (MobileProvisionPlatform platform, bool includeExpired)
 		{
-			if (!Directory.Exists (ProfileDirectory))
-				return new MobileProvision [0];
-
 			var uuids = new Dictionary<string, MobileProvision> ();
 			var list = new List<MobileProvision> ();
 			var now = DateTime.Now;
@@ -174,33 +168,38 @@ namespace Xamarin.MacDev {
 				throw new ArgumentOutOfRangeException (nameof (platform));
 			}
 
-			foreach (var file in Directory.EnumerateFiles (ProfileDirectory, pattern)) {
-				try {
-					var data = File.ReadAllBytes (file);
+			foreach (var profileDir in ProfileDirectories) {
+				if (!Directory.Exists (profileDir))
+					continue;
 
-					var m = new MobileProvision ();
-					m.Load (PDictionary.FromBinaryXml (data));
-					m.Data = data;
+				foreach (var file in Directory.EnumerateFiles (profileDir, pattern)) {
+					try {
+						var data = File.ReadAllBytes (file);
 
-					if (includeExpired || m.ExpirationDate > now) {
-						if (uuids.ContainsKey (m.Uuid)) {
-							// we always want the most recently created/updated provision
-							if (m.CreationDate > uuids [m.Uuid].CreationDate) {
-								int index = list.IndexOf (uuids [m.Uuid]);
-								uuids [m.Uuid] = m;
-								list [index] = m;
+						var m = new MobileProvision ();
+						m.Load (PDictionary.FromBinaryXml (data));
+						m.Data = data;
+
+						if (includeExpired || m.ExpirationDate > now) {
+							if (uuids.ContainsKey (m.Uuid)) {
+								// we always want the most recently created/updated provision
+								if (m.CreationDate > uuids [m.Uuid].CreationDate) {
+									int index = list.IndexOf (uuids [m.Uuid]);
+									uuids [m.Uuid] = m;
+									list [index] = m;
+								}
+							} else {
+								uuids.Add (m.Uuid, m);
+								list.Add (m);
 							}
-						} else {
-							uuids.Add (m.Uuid, m);
-							list.Add (m);
 						}
+					} catch (Exception ex) {
+						LoggingService.LogWarning ("Error reading " + platform + " provision file '" + file + "'", ex);
 					}
-				} catch (Exception ex) {
-					LoggingService.LogWarning ("Error reading " + platform + " provision file '" + file + "'", ex);
 				}
 			}
 
-			//newest first
+			// newest first
 			list.Sort ((x, y) => y.CreationDate.CompareTo (x.CreationDate));
 
 			return list;

--- a/Xamarin.MacDev/MobileProvision.cs
+++ b/Xamarin.MacDev/MobileProvision.cs
@@ -57,7 +57,16 @@ namespace Xamarin.MacDev {
 			if (Environment.OSVersion.Platform == PlatformID.MacOSX
 				|| Environment.OSVersion.Platform == PlatformID.Unix) {
 				string personal = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-				ProfileDirectory = Path.Combine (personal, "Library", "MobileDevice", "Provisioning Profiles");
+
+				// Xcode >= 16.x uses ~/Library/Developer/Xcode/UserData/Provisioning Profiles
+				string profileDir = Path.Combine (personal, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles");
+
+				if (!Directory.Exists (profileDir)) {
+					// Xcode < 16.x uses ~/Library/MobileDevice/Provisioning Profiles
+					profileDir = Path.Combine (personal, "Library", "MobileDevice", "Provisioning Profiles");
+				}
+
+				ProfileDirectory = profileDir;
 			} else {
 				ProfileDirectory = Path.Combine (
 					Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData),

--- a/Xamarin.MacDev/MobileProvisionIndex.cs
+++ b/Xamarin.MacDev/MobileProvisionIndex.cs
@@ -263,7 +263,7 @@ namespace Xamarin.MacDev {
 			}
 		}
 
-		public static MobileProvisionIndex CreateIndex (string[] profileDirs, string indexName)
+		public static MobileProvisionIndex CreateIndex (string [] profileDirs, string indexName)
 		{
 			var index = new MobileProvisionIndex ();
 			var mtime = DateTime.MinValue;
@@ -300,7 +300,7 @@ namespace Xamarin.MacDev {
 			return index;
 		}
 
-		static bool AnyProfileDirModifiedSince (string[] dirs, DateTime mtime)
+		static bool AnyProfileDirModifiedSince (string [] dirs, DateTime mtime)
 		{
 			foreach (var dir in dirs) {
 				if (!Directory.Exists (dir)) {
@@ -318,7 +318,7 @@ namespace Xamarin.MacDev {
 			return false;
 		}
 
-		public static MobileProvisionIndex OpenIndex (string[] profileDirs, string indexName)
+		public static MobileProvisionIndex OpenIndex (string [] profileDirs, string indexName)
 		{
 			MobileProvisionIndex index;
 


### PR DESCRIPTION
Starting with Xcode 16, the location of cached provisioning profiles has moved from "~/Library/MobileDevice/Provisioning Profiles" to "~/Library/Developer/Xcode/UserData/Provisioning Profiles"

Fixes https://github.com/xamarin/xamarin-macios/issues/20771