### PR TITLE
Fix compiler error with C# 14.

### DIFF
--- a/Xamarin.MacDev/EntitlementExtensions.cs
+++ b/Xamarin.MacDev/EntitlementExtensions.cs
@@ -81,7 +81,7 @@ namespace Xamarin.MacDev {
 				if (allKeys == null) {
 					allKeys = typeof (EntitlementKeys).GetFields (BindingFlags.Public | BindingFlags.Static).
 						Where (f => f.FieldType == typeof (string)).
-						Select (field => (string) field.GetValue (null)).
+						Select (f => (string) f.GetValue (null)).
 						ToArray ();
 				}
 


### PR DESCRIPTION
Fixes:

> error CS9273: In language version 14.0, 'field' is a keyword within a property accessor. Rename the variable or use the identifier '@field' instead.