### PR TITLE
Multi-target with .NET 10.

### DIFF
--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net10.0</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.1.0" />

--- a/Xamarin.MacDev/Keychain.cs
+++ b/Xamarin.MacDev/Keychain.cs
@@ -458,7 +458,11 @@ namespace Xamarin.MacDev {
 
 					if (rawData != null) {
 						try {
+#if NET9_0_OR_GREATER
+							certificate = X509CertificateLoader.LoadCertificate (rawData);
+#else
 							certificate = new X509Certificate2 (rawData);
+#endif
 						} catch (Exception ex) {
 							LoggingService.LogWarning ("Error loading signing certificate from keychain", ex);
 						}
@@ -515,7 +519,11 @@ namespace Xamarin.MacDev {
 
 					if (rawData != null) {
 						try {
+#if NET9_0_OR_GREATER
+							certs.Add (X509CertificateLoader.LoadCertificate (rawData));
+#else
 							certs.Add (new X509Certificate2 (rawData));
+#endif
 						} catch (Exception ex) {
 							LoggingService.LogWarning ("Error loading signing certificate from keychain", ex);
 						}

--- a/Xamarin.MacDev/MobileProvision.cs
+++ b/Xamarin.MacDev/MobileProvision.cs
@@ -220,7 +220,11 @@ namespace Xamarin.MacDev {
 				var data = item as PData;
 
 				if (data != null)
+#if NET9_0_OR_GREATER
+					list.Add (X509CertificateLoader.LoadCertificate (data.Value));
+#else
 					list.Add (new X509Certificate2 (data.Value));
+#endif
 			}
 
 			return list;

--- a/Xamarin.MacDev/Xamarin.MacDev.csproj
+++ b/Xamarin.MacDev/Xamarin.MacDev.csproj
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">


### PR DESCRIPTION
This way we can detect and fix any problems when building against newer .NET versions.

Also fix any problems, and turn on warnings as errors.