### PR TITLE
Fix duplicate --results-directory in Azure Pipelines test steps

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -48,16 +48,34 @@ jobs:
     inputs:
       command: test
       projects: UnitTests/UnitTests.csproj
+      publishTestResults: false
       arguments: -c Release --logger "console;verbosity=detailed" --logger trx --results-directory $(Build.ArtifactStagingDirectory)/test-results
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+  - task: PublishTestResults@2
+    displayName: Publish Test Results (Windows)
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**/*.trx'
+      searchFolder: $(Build.ArtifactStagingDirectory)/test-results
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   - task: DotNetCoreCLI@2
     displayName: Run Tests (macOS)
     inputs:
       command: test
       projects: UnitTests/UnitTests.csproj
+      publishTestResults: false
       arguments: -c Release -f net10.0 --logger "console;verbosity=detailed" --logger trx --results-directory $(Build.ArtifactStagingDirectory)/test-results
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+
+  - task: PublishTestResults@2
+    displayName: Publish Test Results (macOS)
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**/*.trx'
+      searchFolder: $(Build.ArtifactStagingDirectory)/test-results
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Darwin'))
 
   - powershell: |
       $hashOfLastVersionChange = & "git" "log" "--follow" "-1" "--pretty=%H" "nuget.version"


### PR DESCRIPTION
The `DotNetCoreCLI@2` task with `command: test` automatically injects `--logger trx --results-directory $(Agent.TempDirectory)` before the custom arguments. This causes a duplicate `--results-directory` error with .NET 10 SDK which is stricter about repeated options.

**Build failure:** https://dev.azure.com/dnceng-public/public/_build/results?buildId=1310068

**Error:**
```
Option '--results-directory' expects a single argument but 2 were provided.
```

**Fix:**
- Set `publishTestResults: false` on both test steps to suppress the auto-injected args
- Add explicit `PublishTestResults@2` tasks to preserve test result publishing in the AzDO UI