### PR TITLE
Fix test infrastructure: enable test execution and fix TestHelper path resolution

### DIFF
--- a/tests/TestHelper.cs
+++ b/tests/TestHelper.cs
@@ -52,9 +52,9 @@ namespace Tests {
 
 			var dir = Path.GetDirectoryName (codeBase);
 
-			while (!string.Equals (Path.GetFileName (dir), "tests", StringComparison.Ordinal)) {
+			while (!IsTestsProjectDir (dir)) {
 				var candidate = Path.Combine (dir, "tests");
-				if (Directory.Exists (candidate)) {
+				if (Directory.Exists (candidate) && IsTestsProjectDir (candidate)) {
 					dir = candidate;
 					break;
 				}
@@ -67,6 +67,12 @@ namespace Tests {
 			}
 
 			ProjectDir = Path.GetFullPath (dir);
+		}
+
+		static bool IsTestsProjectDir (string dir)
+		{
+			return string.Equals (Path.GetFileName (dir), "tests", StringComparison.Ordinal)
+				&& File.Exists (Path.Combine (dir, "tests.csproj"));
 		}
 	}
 }

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net472;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('windows'))">net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Set 'IsTestProject=true' in tests.csproj so that the arcade build
system actually runs the tests.

Fix TestHelper.ProjectDir resolving to artifacts/bin/tests/ instead of
the source tests/ directory. With the arcade build system, the test
assembly output goes to artifacts/bin/tests/Debug/net10.0/. The old
logic walked up from the assembly location and stopped at the first
directory named 'tests', which matched artifacts/bin/tests/ — a
directory that doesn't contain the actual test data files.

Add an IsTestsProjectDir helper that also checks for tests.csproj,
ensuring we find the source tests/ directory with the real TestData.