### PR TITLE
Fix ArgumentNullException in AppleSdkSettings when no settings file exists

### DIFF
--- a/Xamarin.MacDev/AppleSdkSettings.cs
+++ b/Xamarin.MacDev/AppleSdkSettings.cs
@@ -28,6 +28,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 // Disable until we get around to enable + fix any issues.
 #nullable disable
@@ -141,6 +142,10 @@ namespace Xamarin.MacDev {
 				SettingsPath = path;
 				break;
 			}
+
+			// If no existing settings file was found, default to the first candidate path.
+			if (SettingsPath is null)
+				SettingsPath = XcodeLocator.SettingsPathCandidates.First ();
 
 			Directory.CreateDirectory (Path.GetDirectoryName (SettingsPath));
 


### PR DESCRIPTION
The static constructor iterates over SettingsPathCandidates looking for an existing settings file (maui/Settings.plist or Xamarin/Settings.plist). When neither file exists — which happens on fresh machines or CI agents that have never configured an Xcode path — SettingsPath remains null.

This causes Directory.CreateDirectory(Path.GetDirectoryName(null)) to throw System.ArgumentNullException at line 145 (parameter 'path'), which propagates as a TypeInitializationException and ultimately fails the DetectSdkLocations MSBuild task, breaking all builds.

Fix: after the loop, if no existing settings file was found, default SettingsPath to the first candidate (~/Library/Preferences/maui/Settings.plist). This ensures the directory is created and Init() can proceed to discover Xcode via xcode-select or other fallback mechanisms.