### PR TITLE
Fix PathUtils.IsSymlink throwing on common lstat failures

### DIFF
--- a/Xamarin.MacDev/PathUtils.cs
+++ b/Xamarin.MacDev/PathUtils.cs
@@ -48,6 +48,15 @@ namespace Xamarin.MacDev {
 			}
 		}
 
+		const int ENOENT = 2;
+		const int EACCES = 13;
+		const int ENOTDIR = 20;
+
+		/// <summary>
+		/// Returns whether the given path is a symlink.
+		/// Returns false (rather than throwing) when the path cannot be examined
+		/// due to non-existence, permissions, or a non-directory path component.
+		/// </summary>
 		public static bool IsSymlink (string file)
 		{
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
@@ -56,8 +65,12 @@ namespace Xamarin.MacDev {
 			}
 			Stat buf;
 			var rv = lstat (file, out buf);
-			if (rv != 0)
-				throw new Exception (string.Format ("Could not lstat '{0}': {1}", file, Marshal.GetLastWin32Error ()));
+			if (rv != 0) {
+				var errno = Marshal.GetLastWin32Error ();
+				if (errno == ENOENT || errno == EACCES || errno == ENOTDIR)
+					return false;
+				throw new Exception (string.Format ("Could not lstat '{0}': {1}", file, errno));
+			}
 			const int S_IFLNK = 40960;
 			return (buf.st_mode & S_IFLNK) == S_IFLNK;
 		}

--- a/Xamarin.MacDev/Xamarin.MacDev.csproj
+++ b/Xamarin.MacDev/Xamarin.MacDev.csproj
@@ -39,6 +39,9 @@
     <Compile Remove="NullableAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="8.0.5" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
 </Project>

--- a/tests/PathUtilsTests.cs
+++ b/tests/PathUtilsTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using Xamarin.MacDev;
+
+namespace tests {
+
+	[TestFixture]
+	public class PathUtilsTests {
+
+		[Test]
+		[Platform ("MacOsX")]
+		public void IsSymlink_ReturnsFalse_ForNonExistentFile ()
+		{
+			var path = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			// Should not throw; returns false for ENOENT
+			Assert.That (PathUtils.IsSymlink (path), Is.False);
+		}
+
+		[Test]
+		[Platform ("MacOsX")]
+		public void IsSymlink_ReturnsFalse_ForRegularFile ()
+		{
+			var path = Path.GetTempFileName ();
+			try {
+				Assert.That (PathUtils.IsSymlink (path), Is.False);
+			} finally {
+				File.Delete (path);
+			}
+		}
+
+		[Test]
+		[Platform ("MacOsX")]
+		public void IsSymlink_ReturnsTrue_ForSymlink ()
+		{
+			var target = Path.GetTempFileName ();
+			var link = target + ".link";
+			try {
+#if NET
+				File.CreateSymbolicLink (link, target);
+#else
+				// File.CreateSymbolicLink is not available on net472.
+				// Use a shell command to create the symlink on macOS.
+				var psi = new System.Diagnostics.ProcessStartInfo ("ln", $"-s \"{target}\" \"{link}\"") {
+					UseShellExecute = false,
+				};
+				System.Diagnostics.Process.Start (psi)!.WaitForExit ();
+#endif
+				Assert.That (PathUtils.IsSymlink (link), Is.True);
+			} finally {
+				File.Delete (link);
+				File.Delete (target);
+			}
+		}
+
+		[Test]
+		[Platform ("MacOsX")]
+		public void IsSymlinkOrHasParentSymlink_ReturnsFalse_ForNonExistentPath ()
+		{
+			var path = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			Assert.That (PathUtils.IsSymlinkOrHasParentSymlink (path), Is.False);
+		}
+
+		[Test]
+		[Platform ("MacOsX")]
+		public void IsSymlink_ReturnsFalse_WhenPathComponentIsNotDirectory ()
+		{
+			// /etc/hosts is a file, so /etc/hosts/bogus triggers ENOTDIR
+			var path = Path.Combine ("/etc/hosts", "bogus");
+			Assert.That (PathUtils.IsSymlink (path), Is.False);
+		}
+	}
+}

--- a/tests/PathUtilsTests.cs
+++ b/tests/PathUtilsTests.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System;
 using System.IO;
 using NUnit.Framework;
 using Xamarin.MacDev;
@@ -73,6 +72,34 @@ namespace tests {
 			// /etc/hosts is a file, so /etc/hosts/bogus triggers ENOTDIR
 			var path = Path.Combine ("/etc/hosts", "bogus");
 			Assert.That (PathUtils.IsSymlink (path), Is.False);
+		}
+
+		[Test]
+		[Platform ("MacOsX")]
+		public void IsSymlinkOrHasParentSymlink_ReturnsTrue_WhenParentIsSymlink ()
+		{
+			var realDir = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			Directory.CreateDirectory (realDir);
+			var childDir = Path.Combine (realDir, "subdir");
+			Directory.CreateDirectory (childDir);
+
+			var linkDir = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			try {
+#if NET
+				Directory.CreateSymbolicLink (linkDir, realDir);
+#else
+				var psi = new System.Diagnostics.ProcessStartInfo ("ln", $"-s \"{realDir}\" \"{linkDir}\"") {
+					UseShellExecute = false,
+				};
+				System.Diagnostics.Process.Start (psi)!.WaitForExit ();
+#endif
+				var childViaLink = Path.Combine (linkDir, "subdir");
+				Assert.That (PathUtils.IsSymlinkOrHasParentSymlink (childViaLink), Is.True);
+			} finally {
+				if (Directory.Exists (linkDir))
+					Directory.Delete (linkDir);
+				Directory.Delete (realDir, recursive: true);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`IsSymlink` previously threw for any `lstat` failure, including file-not-found and permission-denied. These are expected when walking directory trees (e.g. `IsSymlinkOrHasParentSymlink`).

Now returns `false` for ENOENT (2), EACCES (13), and ENOTDIR (20), only throwing for genuinely unexpected errors.

## Testing

Added `PathUtilsTests` with 4 tests verifying behavior for non-existent files, regular files, symlinks, and parent-symlink traversal.

Also adds `InternalsVisibleTo` for the test assembly.